### PR TITLE
ResponseDTO에 대한 제안입니다

### DIFF
--- a/src/main/java/com/yanolja_final/global/config/AppConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/AppConfig.java
@@ -1,0 +1,22 @@
+package com.yanolja_final.global.config;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * 오직 Bean 등록 하나만 하는 등의 단순 설정을 모아두는 클래스
+ * (빈 등록이나 설정을 여러 개 해야 한다면 SecurityConfig 등으로 클래스를 따로 파는 것 권장)
+ */
+@Configuration
+public class AppConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        ObjectMapper objectMapper = new ObjectMapper();
+        // RestController에서 json 응답 시 null 값의 필드는 아예 보여주지 않도록 설정하는 부분
+        objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
+        return objectMapper;
+    }
+}

--- a/src/main/java/com/yanolja_final/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/yanolja_final/global/exception/GlobalExceptionRestAdvice.java
@@ -14,35 +14,35 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionRestAdvice {
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDTO<Object>> applicationException(ApplicationException e) {
+    public ResponseEntity<ResponseDTO<Void>> applicationException(ApplicationException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
             .status(e.getErrorCode().getHttpStatus())
-            .body(ResponseDTO.res(e.getErrorCode().getHttpStatus(), e.getErrorCode().getMessage()));
+            .body(ResponseDTO.error(e.getErrorCode()));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDTO<Object>> bindException(BindException e) {
+    public ResponseEntity<ResponseDTO<Void>> bindException(BindException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
             .status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDTO.res(HttpStatus.BAD_REQUEST,
+            .body(ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST,
                 e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDTO<Object>> dbException(DataAccessException e) {
+    public ResponseEntity<ResponseDTO<Void>> dbException(DataAccessException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
+            .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
     }
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDTO<Object>> serverException(RuntimeException e) {
+    public ResponseEntity<ResponseDTO<Void>> serverException(RuntimeException e) {
         log.error(e.getMessage(), e);
         return ResponseEntity
             .status(HttpStatus.INTERNAL_SERVER_ERROR)
-            .body(ResponseDTO.res(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
+            .body(ResponseDTO.errorWithMessage(HttpStatus.INTERNAL_SERVER_ERROR, "서버 에러!"));
     }
 }

--- a/src/main/java/com/yanolja_final/global/util/ResponseDTO.java
+++ b/src/main/java/com/yanolja_final/global/util/ResponseDTO.java
@@ -1,5 +1,6 @@
 package com.yanolja_final.global.util;
 
+import com.yanolja_final.global.exception.ErrorCode;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
@@ -8,37 +9,45 @@ import org.springframework.http.HttpStatus;
 public class ResponseDTO<T> {
 
     private final int code;
-    private final String message;
     private final T data;
+    private final String errorMessage;
 
     @Builder
-    private ResponseDTO(int code, String message, T data) {
+    private ResponseDTO(int code, String errorMessage, T data) {
         this.code = code;
-        this.message = message;
+        this.errorMessage = errorMessage;
         this.data = data;
     }
 
-    public static ResponseDTO<Object> res(final HttpStatus httpStatus, final String message) {
-        return ResponseDTO.<Object>builder()
-            .code(httpStatus.value())
-            .message(message)
+    public static ResponseDTO<Void> ok() {
+        return ResponseDTO.<Void>builder()
+            .code(HttpStatus.OK.value())
+            .data(null)
+            .errorMessage(null)
             .build();
     }
 
-    public static <T> ResponseDTO<T> res(final HttpStatus httpStatus, final T data) {
+    public static <T> ResponseDTO<T> okWithData(T data) {
         return ResponseDTO.<T>builder()
-            .code(httpStatus.value())
+            .code(HttpStatus.OK.value())
             .data(data)
+            .errorMessage(null)
             .build();
     }
 
-    public static <T> ResponseDTO<T> res(final HttpStatus httpStatus,
-        final String message,
-        final T data) {
-        return ResponseDTO.<T>builder()
+    public static ResponseDTO<Void> error(ErrorCode errorCode) {
+        return ResponseDTO.<Void>builder()
+            .code(errorCode.getHttpStatus().value())
+            .errorMessage(errorCode.getMessage())
+            .data(null)
+            .build();
+    }
+
+    public static ResponseDTO<Void> errorWithMessage(HttpStatus httpStatus, String errorMessage) {
+        return ResponseDTO.<Void>builder()
             .code(httpStatus.value())
-            .message(message)
-            .data(data)
+            .errorMessage(errorMessage)
+            .data(null)
             .build();
     }
 }


### PR DESCRIPTION
## ⭐ 개요

### 종류

- [X] 제안

### 📑 주요 작성/변경사항

### ResponseDTO 구조를 개편했습니다.

1. message 필드를 errorMessage로 변경했습니다.

- '성공 시 메시지'를 보내주지 않아도 괜찮을 것 같습니다.
  - 성공했다는 사실을 알리는 것은 상태 코드 200으로도 충분하다고 생각합니다.
  - 프론트 입장에서도 '성공 시 메시지'를 크게 활용하는 경우는 없었을 거라고 생각됩니다.

2. 정적 팩토리 메서드를 ok, okWithData, error, errorWithMessage로 개편했습니다.

- ok(): 아무런 메시지 없이 성공했다는 것을 알릴 때
- okWithData(data): 특정 DTO와 같이 성공했다는 것을 알릴 때
- error(errorCode): RestAdvice에서 applicationException을 처리할 때 사용
- errorWithMessage(httpStatus, errorMessage): RestAdvice에서 applicationException 외의 모든 예외를 처리할 때 사용


### `@RestController` json 응답 시 null인 필드는 아예 보여주지 않도록 했습니다

관련 커밋 링크: https://github.com/yanolja-finalproject/Backend/commit/5461b5e00cfcd7037442ac8779a17ad031a4e74f