### PR TITLE
[Feature] Spring Security JWT 인증 및 기본 인가 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,9 @@ dependencies {
     implementation 'org.yaml:snakeyaml:+'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.5'
+    runtimeOnly group: 'io.jsonwebtoken', name: 'jjwt-jackson', version: '0.11.5'
 }
 
 tasks.named('bootBuildImage') {

--- a/src/main/java/com/yanolja_final/domain/user/controller/request/SignUpRequest.java
+++ b/src/main/java/com/yanolja_final/domain/user/controller/request/SignUpRequest.java
@@ -1,9 +1,11 @@
 package com.yanolja_final.domain.user.controller.request;
 
+import com.yanolja_final.domain.user.entity.Authority;
 import com.yanolja_final.domain.user.entity.User;
 import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
+import java.util.Set;
 
 public record SignUpRequest(
     @Email(message = "email의 형식이 잘못됐습니다.")
@@ -15,10 +17,11 @@ public record SignUpRequest(
     String password
 ) {
 
-    public User toEntity(String encryptedPassword) {
+    public User toEntity(String encryptedPassword, Set<Authority> authorities) {
         return User.builder()
             .email(email)
             .encryptedPassword(encryptedPassword)
+            .authorities(authorities)
             .build();
     }
 }

--- a/src/main/java/com/yanolja_final/domain/user/entity/Authority.java
+++ b/src/main/java/com/yanolja_final/domain/user/entity/Authority.java
@@ -1,0 +1,17 @@
+package com.yanolja_final.domain.user.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+public class Authority {
+
+    @Id
+    private String name;
+}

--- a/src/main/java/com/yanolja_final/domain/user/entity/User.java
+++ b/src/main/java/com/yanolja_final/domain/user/entity/User.java
@@ -6,9 +6,11 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.MapKeyColumn;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinTable;
+import jakarta.persistence.ManyToMany;
 import jakarta.persistence.Table;
-import jakarta.persistence.UniqueConstraint;
+import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -28,9 +30,17 @@ public class User extends BaseTimeEntity {
 
     private String encryptedPassword;
 
+    @ManyToMany
+    @JoinTable(
+        name = "user_authority",
+        joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
+        inverseJoinColumns = {@JoinColumn})
+    private Set<Authority> authorities;
+
     @Builder
-    private User(String email, String encryptedPassword) {
+    private User(String email, String encryptedPassword, Set<Authority> authorities) {
         this.email = email;
         this.encryptedPassword = encryptedPassword;
+        this.authorities = authorities;
     }
 }

--- a/src/main/java/com/yanolja_final/domain/user/service/UserService.java
+++ b/src/main/java/com/yanolja_final/domain/user/service/UserService.java
@@ -2,11 +2,12 @@ package com.yanolja_final.domain.user.service;
 
 import com.yanolja_final.domain.user.controller.request.SignUpRequest;
 import com.yanolja_final.domain.user.controller.response.SignUpResponse;
+import com.yanolja_final.domain.user.entity.Authority;
 import com.yanolja_final.domain.user.entity.User;
 import com.yanolja_final.domain.user.exception.UserAlreadyRegisteredException;
 import com.yanolja_final.domain.user.repository.UserRepository;
-import com.yanolja_final.global.exception.ApplicationException;
-import com.yanolja_final.global.exception.ErrorCode;
+import java.util.Collections;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -17,6 +18,8 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class UserService {
 
+    public static final Set<Authority> DEFAULT_AUTHORITIES =
+        Collections.singleton(new Authority("ROLE_USER"));
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
 
@@ -27,7 +30,7 @@ public class UserService {
         }
 
         String encryptedPassword = passwordEncoder.encode(signUpRequest.password());
-        User user = signUpRequest.toEntity(encryptedPassword);
+        User user = signUpRequest.toEntity(encryptedPassword, DEFAULT_AUTHORITIES);
 
         User savedUser = userRepository.save(user);
         return SignUpResponse.from(savedUser);

--- a/src/main/java/com/yanolja_final/global/common/BaseTimeEntity.java
+++ b/src/main/java/com/yanolja_final/global/common/BaseTimeEntity.java
@@ -6,6 +6,8 @@ import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
 import java.time.LocalDateTime;
 import lombok.Getter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
@@ -15,10 +17,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseTimeEntity {
 
-    @CreatedDate
+    @CreationTimestamp
     protected LocalDateTime createdAt;
 
-    @LastModifiedDate
+    @UpdateTimestamp
     protected LocalDateTime updatedAt;
 
     @Column(insertable = false)

--- a/src/main/java/com/yanolja_final/global/config/AppConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/AppConfig.java
@@ -4,12 +4,8 @@ import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
-import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
-import org.springframework.security.web.SecurityFilterChain;
 
 /**
  * 오직 Bean 등록 하나만 하는 등의 단순 설정을 모아두는 클래스
@@ -24,18 +20,6 @@ public class AppConfig {
         // RestController에서 json 응답 시 null 값의 필드는 아예 보여주지 않도록 설정하는 부분
         objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         return objectMapper;
-    }
-
-    // 임시 Security 설정
-    @Bean
-    public SecurityFilterChain temporarySecurityFilterChain(HttpSecurity http) throws Exception {
-        http
-            .csrf(AbstractHttpConfigurer::disable)
-            .authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-                .anyRequest().permitAll())
-            .sessionManagement(sessionManagement -> sessionManagement
-                .sessionCreationPolicy(SessionCreationPolicy.STATELESS));
-        return http.build();
     }
 
     @Bean

--- a/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
@@ -1,17 +1,24 @@
 package com.yanolja_final.global.config.security;
 
+import java.util.Arrays;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @EnableWebSecurity
 @Configuration
 public class SecurityConfig {
+
+    private static final String[] WHITELIST_FOR_ALL_METHOD
+        = {};
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -28,8 +35,11 @@ public class SecurityConfig {
             headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
         );
 
+        // REST API의 URI에 대한 인가 적용/미적용 설정
         http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-            .anyRequest().permitAll()
+            .requestMatchers(WHITELIST_FOR_ALL_METHOD).permitAll()
+            .requestMatchers(HttpMethod.POST.name(), "/v1/user").permitAll()
+            .anyRequest().authenticated()
         );
 
         return http.build();

--- a/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
@@ -22,7 +22,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private static final String[] WHITELIST_FOR_ALL_METHOD
+    private static final String[] ALLOWED_PATHS
         = { "/v1/docs/**" };
 
     private final JwtFilter jwtFilter;
@@ -56,7 +56,7 @@ public class SecurityConfig {
         // REST API의 URI에 대한 인가 적용/미적용 설정
         http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
             .requestMatchers(
-                Arrays.stream(WHITELIST_FOR_ALL_METHOD)
+                Arrays.stream(ALLOWED_PATHS)
                     .map(AntPathRequestMatcher::new)
                     .toArray(RequestMatcher[]::new)
             ).permitAll()

--- a/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.yanolja_final.global.config.security;
 
 import com.yanolja_final.global.config.security.jwt.JwtFilter;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -13,6 +14,8 @@ import org.springframework.security.config.annotation.web.configurers.HeadersCon
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
 
 @EnableWebSecurity
 @Configuration
@@ -52,8 +55,14 @@ public class SecurityConfig {
 
         // REST API의 URI에 대한 인가 적용/미적용 설정
         http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
-            .requestMatchers(WHITELIST_FOR_ALL_METHOD).permitAll()
-            .requestMatchers(HttpMethod.POST.name(), "/v1/user").permitAll()
+            .requestMatchers(
+                Arrays.stream(WHITELIST_FOR_ALL_METHOD)
+                    .map(AntPathRequestMatcher::new)
+                    .toArray(RequestMatcher[]::new)
+            ).permitAll()
+            .requestMatchers(
+                new AntPathRequestMatcher("/v1/user", HttpMethod.POST.name())
+            ).permitAll()
             .anyRequest().authenticated()
         );
 

--- a/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
@@ -23,7 +23,7 @@ import org.springframework.security.web.util.matcher.RequestMatcher;
 public class SecurityConfig {
 
     private static final String[] WHITELIST_FOR_ALL_METHOD
-        = {};
+        = { "/v1/docs/**" };
 
     private final JwtFilter jwtFilter;
 

--- a/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
@@ -5,6 +5,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 
@@ -21,6 +22,11 @@ public class SecurityConfig {
                 .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
             )
         ;
+
+        // h2-console을 위한 FrameOption 허용
+        http.headers(headers ->
+            headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin)
+        );
 
         http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
             .anyRequest().permitAll()

--- a/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/security/SecurityConfig.java
@@ -1,0 +1,31 @@
+package com.yanolja_final.global.config.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@EnableWebSecurity
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        // JWT 인증을 사용하므로 CSRF 보안 해제 및 세션 사용안함 설정
+        http
+            .csrf(AbstractHttpConfigurer::disable)
+            .sessionManagement(sessionManagement -> sessionManagement
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            )
+        ;
+
+        http.authorizeHttpRequests(authorizeHttpRequests -> authorizeHttpRequests
+            .anyRequest().permitAll()
+        );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/yanolja_final/global/config/security/jwt/JwtFilter.java
+++ b/src/main/java/com/yanolja_final/global/config/security/jwt/JwtFilter.java
@@ -1,0 +1,60 @@
+package com.yanolja_final.global.config.security.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class JwtFilter extends GenericFilterBean {
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "accessToken";
+
+    private final JwtProvider jwtProvider;
+
+    @Override
+    public void doFilter(
+        ServletRequest request, ServletResponse response, FilterChain chain
+    ) throws IOException, ServletException {
+        HttpServletRequest httpServletRequest = (HttpServletRequest) request;
+        String requestURI = httpServletRequest.getRequestURI();
+
+        String accessToken = resolveToken(httpServletRequest);
+        if (StringUtils.hasText(accessToken) && jwtProvider.validateToken(accessToken)) {
+            Authentication authentication = jwtProvider.getAuthentication(accessToken);
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+            log.debug(
+                "Security Context에 '{}' 인증 정보를 저장했습니다, uri: {}",
+                authentication.getName(), requestURI
+            );
+        } else {
+            log.debug("유효한 JWT 토큰이 없습니다, uri: {}", requestURI);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies == null) return null;
+
+        for (Cookie cookie : cookies) {
+            if (ACCESS_TOKEN_COOKIE_NAME.equals(cookie.getName())) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,3 +17,4 @@ spring:
       hibernate:
         show_sql: true
         format_sql: true
+    defer-datasource-initialization: true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -18,3 +18,7 @@ spring:
         show_sql: true
         format_sql: true
     defer-datasource-initialization: true
+
+jwt:
+  secret: c2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQtc2lsdmVybmluZS10ZWNoLXNwcmluZy1ib290LWp3dC10dXRvcmlhbC1zZWNyZXQK
+  token-validity-in-seconds: 86400

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,0 +1,1 @@
+INSERT INTO authority(name) VALUES('ROLE_USER');

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -15,6 +15,10 @@
     </encoder>
     <file>${LOGS}/spring-boot-logger.log</file>
 
+    <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+      <level>ERROR</level>
+    </filter>
+
     <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
       <fileNamePattern>${LOGS}/archived/spring-boot-logger-%d{yyyy-MM-dd}.%i.log</fileNamePattern>
       <maxHistory>20</maxHistory>
@@ -29,7 +33,7 @@
 
   <property name="LOGS" value="./logs"/>
 
-  <root level="ERROR">
+  <root level="INFO">
     <appender-ref ref="CONSOLE"/>
     <appender-ref ref="RollingFile"/>
   </root>


### PR DESCRIPTION
closes #15 

## ⭐ 개요

### 종류
- [X] New Feature
- [X] Bug Fix

### 📑 주요 작성/변경사항

- Authority 엔티티 생성 및 User 엔티티에 Set<Authority> authorities 필드 추가
  - 원래는 Security 권한 개념 없이 가려는 생각이였는데
  - 나중에 어드민 페이지를 생성한다고 가정할때 확장성 면에서 너무 좋지 않은 것 같아서 마음을 바꿈
- JWT 인증 구현
  - Security Filter를 통해 매 요청마다 'accessToken' 쿠키의 값을 확인하여
  - 유효한 토큰이라면 사용자의 정보(user 고유번호)를 SecurityContextHolder에 저장
- 기본 인가 구현
  - H2 Console 허용
  - POST /user 회원가입 허용

### 💡 특이 사항 

- Logback 설정 변경 (콘솔은 INFO, 파일은 ERROR 레벨)
  - 현재 설정상 콘솔에도 ERROR 레벨로 로그되고 있었음
- createdAt, updatedAt null로 담기는 문제 해결
  - 다른 어노테이션을 사용해야 제대로 담겼음
