### PR TITLE
[Feat] 로그인된 userId 편하게 가져오는 ArgumentResolver 구현

### DIFF
--- a/src/main/java/com/yanolja_final/global/config/argumentresolver/ArgumentResolverConfig.java
+++ b/src/main/java/com/yanolja_final/global/config/argumentresolver/ArgumentResolverConfig.java
@@ -1,0 +1,15 @@
+package com.yanolja_final.global.config.argumentresolver;
+
+import java.util.List;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class ArgumentResolverConfig implements WebMvcConfigurer {
+
+    @Override
+    public void addArgumentResolvers(List<HandlerMethodArgumentResolver> argumentResolvers) {
+        argumentResolvers.add(new LoginedUserIdArgumentResolver());
+    }
+}

--- a/src/main/java/com/yanolja_final/global/config/argumentresolver/LoginedUserId.java
+++ b/src/main/java/com/yanolja_final/global/config/argumentresolver/LoginedUserId.java
@@ -1,0 +1,12 @@
+package com.yanolja_final.global.config.argumentresolver;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.PARAMETER)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface LoginedUserId {
+
+}

--- a/src/main/java/com/yanolja_final/global/config/argumentresolver/LoginedUserIdArgumentResolver.java
+++ b/src/main/java/com/yanolja_final/global/config/argumentresolver/LoginedUserIdArgumentResolver.java
@@ -1,0 +1,35 @@
+package com.yanolja_final.global.config.argumentresolver;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+public class LoginedUserIdArgumentResolver implements HandlerMethodArgumentResolver {
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.getParameterAnnotation(LoginedUserId.class) != null
+            && parameter.getParameterType().equals(Long.class);
+    }
+
+    @Override
+    public Object resolveArgument(MethodParameter parameter, ModelAndViewContainer mavContainer,
+        NativeWebRequest webRequest, WebDataBinderFactory binderFactory) {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+
+        try {
+            return Long.valueOf(authentication.getName());
+        } catch (NumberFormatException e) {
+            // Handle the case where the user name cannot be converted to a Long
+            throw new IllegalArgumentException("User ID is not in the correct format");
+        }
+    }
+}


### PR DESCRIPTION
closes #16 

## ⭐ 개요

### 종류
- [X] New Feature

### 📑 주요 작성/변경사항

<img width="461" alt="image" src="https://github.com/yanolja-finalproject/Backend/assets/33937365/9444266d-fef6-4444-ae0d-7dc3d4f3e71e">

- 위와 같이 @LoginedUserId 어노테이션을 단 Long 형의 매개변수를 컨트롤러에 삽입하면
- 해당 매개변수에 로그인된 사용자의 userId가 들어옵니다.
- `@AuthenticationPrincipal` 어노테이션을 통해서 해야했던 귀찮은 과정을 거치지 않아도 됩니다.
