### PR TITLE
[Feature]  공지사항 글 작성 API

### DIFF
--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -1,0 +1,33 @@
+package com.yanolja_final.domain.notice.controller;
+
+
+import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
+import com.yanolja_final.domain.notice.facade.NoticeFacade;
+import com.yanolja_final.global.util.ResponseDTO;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/notices")
+@RequiredArgsConstructor
+public class NoticeController {
+
+    private final NoticeFacade noticeFacade;
+
+    @PostMapping
+    public ResponseEntity<ResponseDTO<RegisterNoticeResponse>> createNotice(
+        @Valid @RequestBody RegisterNoticeRequest registerNoticeRequest
+    ) {
+        ResponseDTO<RegisterNoticeResponse> response = noticeFacade.registerNotice(
+            registerNoticeRequest);
+
+        return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
@@ -1,19 +1,24 @@
 package com.yanolja_final.domain.notice.dto.request;
 
 import com.yanolja_final.domain.notice.entity.Notice;
+import jakarta.validation.constraints.NotNull;
 
 public record RegisterNoticeRequest(
+    @NotNull
     String title,
+    @NotNull
     String[] content
 ) {
 
     public Notice toEntity() {
 
-        String joinContent = String.join("\n", content);
+        String splitContent = String.join("\n", content);
 
         return Notice.builder()
             .title(title)
-            .content(joinContent)
+            .content(splitContent)
             .build();
     }
 }
+
+

--- a/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
@@ -1,0 +1,19 @@
+package com.yanolja_final.domain.notice.dto.request;
+
+import com.yanolja_final.domain.notice.entity.Notice;
+
+public record RegisterNoticeRequest(
+    String title,
+    String[] content
+) {
+
+    public Notice toEntity() {
+
+        String joinContent = String.join("\n", content);
+
+        return Notice.builder()
+            .title(title)
+            .content(joinContent)
+            .build();
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
@@ -1,0 +1,38 @@
+package com.yanolja_final.domain.notice.dto.response;
+
+import com.yanolja_final.domain.notice.entity.Notice;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+
+public record RegisterNoticeResponse(
+    Long noticeId,
+    String title,
+    String createdAt,
+    String[] content
+
+) {
+
+
+    public static RegisterNoticeResponse from(Notice notice) {
+
+        // "content" : ["",""] 향후 수정 가능성 있음
+        String[] splitContent = notice.getContent().split("\n");
+
+        if (splitContent.length == 0 || (splitContent.length == 1 && splitContent[0].isEmpty())) {
+            splitContent = new String[]{" "," "};
+        }
+
+        return new RegisterNoticeResponse(
+            notice.getId(),
+            notice.getTitle(),
+            getFormattedDate(notice.getCreatedAt()),
+            splitContent
+        );
+    }
+
+    public static String getFormattedDate(LocalDateTime createdAt) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return createdAt.format(formatter);
+    }
+}
+

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
@@ -15,12 +15,7 @@ public record RegisterNoticeResponse(
 
     public static RegisterNoticeResponse from(Notice notice) {
 
-        // "content" : ["",""] 향후 수정 가능성 있음
         String[] splitContent = notice.getContent().split("\n");
-
-        if (splitContent.length == 0 || (splitContent.length == 1 && splitContent[0].isEmpty())) {
-            splitContent = new String[]{" "," "};
-        }
 
         return new RegisterNoticeResponse(
             notice.getId(),

--- a/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
+++ b/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
@@ -6,8 +6,10 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
 
 @Entity
 @NoArgsConstructor
@@ -23,4 +25,10 @@ public class Notice extends BaseTimeEntity {
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String content;
+
+    @Builder
+    public Notice(String title, String content) {
+        this.title = title;
+        this.content = content;
+    }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -1,0 +1,24 @@
+package com.yanolja_final.domain.notice.facade;
+
+
+import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
+import com.yanolja_final.domain.notice.service.NoticeService;
+import com.yanolja_final.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeFacade {
+
+    private final NoticeService noticeService;
+
+    public ResponseDTO<RegisterNoticeResponse> registerNotice(
+        RegisterNoticeRequest registerNoticeRequest) {
+
+        ResponseDTO<RegisterNoticeResponse> registerNoticeResponse = noticeService
+            .registerNotice(registerNoticeRequest);
+        return registerNoticeResponse;
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/notice/repository/NoticeRepository.java
+++ b/src/main/java/com/yanolja_final/domain/notice/repository/NoticeRepository.java
@@ -1,0 +1,8 @@
+package com.yanolja_final.domain.notice.repository;
+
+import com.yanolja_final.domain.notice.entity.Notice;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NoticeRepository extends JpaRepository<Notice, Long> {
+
+}

--- a/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
@@ -1,0 +1,26 @@
+package com.yanolja_final.domain.notice.service;
+
+import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
+import com.yanolja_final.domain.notice.entity.Notice;
+import com.yanolja_final.domain.notice.repository.NoticeRepository;
+import com.yanolja_final.global.util.ResponseDTO;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class NoticeService {
+
+    private final NoticeRepository noticeRepository;
+
+    public ResponseDTO<RegisterNoticeResponse> registerNotice(
+        RegisterNoticeRequest registerNoticeRequest) {
+
+        Notice notice = registerNoticeRequest.toEntity();
+        Notice newNotice = noticeRepository.save(notice);
+
+        return ResponseDTO.okWithData(RegisterNoticeResponse.from(newNotice));
+
+    }
+}


### PR DESCRIPTION
### 포스트맨 실행 결과
![a,b,c 결과](https://github.com/yanolja-finalproject/Backend/assets/129931655/e665f49f-4778-4108-99be-3e2301616175)
<Request "content" : ["a", "b", "c"]>

![결과](https://github.com/yanolja-finalproject/Backend/assets/129931655/1dddb249-6b65-4eb1-98a6-424f47ccd6d6)
<Request "content" : ["" , ""]>

![h2_console](https://github.com/yanolja-finalproject/Backend/assets/129931655/daa75c75-ad46-4345-9577-71dd70ec0af8)
<H2 console>


### 💡 특이 사항 

Request 와 Response -> "content" 부분에서 "\n" 을 기준으로 split하는 로직이 추가되어 있습니다.
JSON value에 값이 있으면 줄바꿈을 기준으로 정상적인 값이 삽입되지만, JSON value에 "" , 즉 empty 값이 들어가면
"content" : [] 이런 식으로 출력이 되는 상황입니다. (H2, Postman, Log, System.out.println 모두 점검 해보았습니다.)

## API design과 같이 아래의 모습처럼 만들어보려 했으나 현재 원인을 파악하지 못한 상황입니다.
RequestBody / "content" : ["",""] --> ResponseBody / "content": ["",""]  







### #️⃣ Issue Link - #12

### Reference
