### PR TITLE
[Feature] 찬반 토론 결과 % 기능 구현

### DIFF
--- a/src/main/java/com/yanolja_final/domain/poll/controller/request/PollAnswerRequest.java
+++ b/src/main/java/com/yanolja_final/domain/poll/controller/request/PollAnswerRequest.java
@@ -13,7 +13,7 @@ public record PollAnswerRequest(
 
     public PollAnswer toEntity(User user, Poll poll) {
         return PollAnswer.builder()
-            .answer(choose)
+            .answer(Character.toUpperCase(choose))
             .user(user)
             .poll(poll)
             .build();

--- a/src/main/java/com/yanolja_final/domain/poll/controller/response/VotedResponse.java
+++ b/src/main/java/com/yanolja_final/domain/poll/controller/response/VotedResponse.java
@@ -10,7 +10,7 @@ public record VotedResponse(
     PollResultDTO B
 ) {
 
-    public static VotedResponse from(Poll poll){
+    public static VotedResponse from(Poll poll) {
         return new VotedResponse(
             true,
             poll.getTitle(),
@@ -19,19 +19,26 @@ public record VotedResponse(
         );
     }
 
-    private static PollResultDTO getAPollResultInfo(Poll poll){
+    private static PollResultDTO getAPollResultInfo(Poll poll) {
         return new PollResultDTO(
             poll.getAName(),
             poll.getAHashtag(),
-            100
+            calculatePercentage(poll.getACount(), poll.getACount() + poll.getBCount())
         );
     }
 
-    private static PollResultDTO getBPollResultInfo(Poll poll){
+    private static PollResultDTO getBPollResultInfo(Poll poll) {
         return new PollResultDTO(
             poll.getBName(),
             poll.getBHashtag(),
-            0
+            calculatePercentage(poll.getBCount(), poll.getACount() + poll.getBCount())
         );
+    }
+
+    private static int calculatePercentage(int count, int totalCount) {
+        if (totalCount == 0) {
+            return 0;
+        }
+        return (int) Math.round(((double) count / totalCount) * 100.0);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/poll/controller/response/VotedResponse.java
+++ b/src/main/java/com/yanolja_final/domain/poll/controller/response/VotedResponse.java
@@ -7,38 +7,17 @@ public record VotedResponse(
     boolean alreadySubmitted,
     String title,
     PollResultDTO A,
-    PollResultDTO B
+    PollResultDTO B,
+    Integer totalCount
 ) {
 
     public static VotedResponse from(Poll poll) {
         return new VotedResponse(
             true,
             poll.getTitle(),
-            getAPollResultInfo(poll),
-            getBPollResultInfo(poll)
+            PollResultDTO.getAPollResultInfo(poll),
+            PollResultDTO.getBPollResultInfo(poll),
+            poll.getACount()+ poll.getBCount()
         );
-    }
-
-    private static PollResultDTO getAPollResultInfo(Poll poll) {
-        return new PollResultDTO(
-            poll.getAName(),
-            poll.getAHashtag(),
-            calculatePercentage(poll.getACount(), poll.getACount() + poll.getBCount())
-        );
-    }
-
-    private static PollResultDTO getBPollResultInfo(Poll poll) {
-        return new PollResultDTO(
-            poll.getBName(),
-            poll.getBHashtag(),
-            calculatePercentage(poll.getBCount(), poll.getACount() + poll.getBCount())
-        );
-    }
-
-    private static int calculatePercentage(int count, int totalCount) {
-        if (totalCount == 0) {
-            return 0;
-        }
-        return (int) Math.round(((double) count / totalCount) * 100.0);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/poll/dto/PollResultDTO.java
+++ b/src/main/java/com/yanolja_final/domain/poll/dto/PollResultDTO.java
@@ -1,9 +1,36 @@
 package com.yanolja_final.domain.poll.dto;
 
+import com.yanolja_final.domain.poll.entity.Poll;
+
 public record PollResultDTO(
     String linkName,
     String linkHashTag,
+    Integer count,
     Integer percentage
 ) {
 
+    public static PollResultDTO getAPollResultInfo(Poll poll) {
+        return new PollResultDTO(
+            poll.getAName(),
+            poll.getAHashtag(),
+            poll.getACount(),
+            calculatePercentage(poll.getACount(), poll.getACount() + poll.getBCount())
+        );
+    }
+
+    public static PollResultDTO getBPollResultInfo(Poll poll) {
+        return new PollResultDTO(
+            poll.getBName(),
+            poll.getBHashtag(),
+            poll.getBCount(),
+            calculatePercentage(poll.getBCount(), poll.getACount() + poll.getBCount())
+        );
+    }
+
+    private static int calculatePercentage(int count, int totalCount) {
+        if (totalCount == 0) {
+            return 0;
+        }
+        return (int) Math.round(((double) count / totalCount) * 100.0);
+    }
 }

--- a/src/main/java/com/yanolja_final/domain/poll/entity/Poll.java
+++ b/src/main/java/com/yanolja_final/domain/poll/entity/Poll.java
@@ -36,6 +36,9 @@ public class Poll extends BaseTimeEntity {
     @Column(length = 100, nullable = false)
     private String aQuestion;
 
+    @Column(nullable = false)
+    private Integer aCount=0;
+
     @Column(length = 50, nullable = false)
     private String bName;
 
@@ -45,10 +48,21 @@ public class Poll extends BaseTimeEntity {
     @Column(length = 100, nullable = false)
     private String bQuestion;
 
+    @Column(nullable = false)
+    private Integer bCount=0;
+
     @OneToMany(
         fetch = FetchType.LAZY,
         mappedBy = "poll",
         cascade = CascadeType.REMOVE
     )
     private List<PollAnswer> pollAnswers;
+
+    public void incrementACount() {
+        this.aCount++;
+    }
+
+    public void incrementBCount() {
+        this.bCount++;
+    }
 }

--- a/src/main/java/com/yanolja_final/domain/poll/exception/InvalidOptionException.java
+++ b/src/main/java/com/yanolja_final/domain/poll/exception/InvalidOptionException.java
@@ -1,0 +1,11 @@
+package com.yanolja_final.domain.poll.exception;
+
+import com.yanolja_final.global.exception.ApplicationException;
+import com.yanolja_final.global.exception.ErrorCode;
+
+public class InvalidOptionException extends ApplicationException {
+
+    public InvalidOptionException() {
+        super(ErrorCode.INVALID_OPTION);
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/poll/service/PollService.java
+++ b/src/main/java/com/yanolja_final/domain/poll/service/PollService.java
@@ -29,13 +29,20 @@ public class PollService {
         if (pollAnswerRepository.existsByUserIdAndPollId(user.getId(), poll.getId())) {
             throw new PollAnswerException();
         }
-
         PollAnswer pollAnswer = request.toEntity(user, poll);
         pollAnswerRepository.save(pollAnswer);
+
+        if (Character.toLowerCase(request.choose()) == 'a') {
+            poll.incrementACount();
+        } else if (Character.toLowerCase(request.choose()) == 'b') {
+            poll.incrementBCount();
+        }
+        pollRepository.save(poll);
     }
 
     public Object findActivePoll(User user) {
         Poll poll = findPollMaxId();
+
         if (pollAnswerRepository.existsByUserIdAndPollId(user.getId(), poll.getId())) {
             return VotedResponse.from(poll);
         } else {

--- a/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
@@ -30,6 +30,7 @@ public enum ErrorCode {
     // POLL
     POLL_NOT_FOUND(HttpStatus.BAD_REQUEST, "등록된 찬/반 토론 이벤트가 없습니다."),
     ALREADY_VOTED(HttpStatus.FORBIDDEN, "이미 투표에 참여 하셨습니다."),
+    INVALID_OPTION(HttpStatus.BAD_REQUEST, "해당 응답은 잘못된 응답입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -1,1 +1,6 @@
 INSERT INTO authority(name) VALUES('ROLE_USER');
+
+INSERT INTO POLL (CREATED_AT, DELETED_AT, ID, UPDATED_AT, A_HASHTAG, A_NAME, B_HASHTAG, B_NAME, A_QUESTION, B_QUESTION, TITLE,A_COUNT,B_COUNT)
+VALUES
+    ('2024-01-03 12:00:00', NULL, 1, '2024-01-03 12:00:00', '#TagA1', 'NameA1', '#TagB1', 'NameB1', 'QuestionA', 'QuestionB', 'Sample Poll 1',0,0),
+    ('2024-01-03 12:30:00', NULL, 2, '2024-01-03 12:30:00', '#TagA2', 'NameA2', '#TagB2', 'NameB2', 'QuestionA'|| CHR(10) ||'문자열 슬라이드'|| CHR(10) ||'테스트용', 'QuestionY', 'Sample Poll 2',0,0)


### PR DESCRIPTION
## ⭐ 개요
_**해당 pr은 `feature/66` 브랜치와 merge될 예정**_

### 종류
- [x] New Feature

### 📑 주요 작성/변경사항
- 투표 테이블에 각각의 count를 계산하는 컬럼 추가
- Answer를 등록하는 api호출 시 선택된 answer의 응답 count +1증가 
- 투표 지문(A,B)에 대해 추가 정보 제공(count, totalCount)
- 찬반 등록하는 api가 별도로 없기에 data.sql에 2개의 poll을 등록하는 sql 추가

### 💡 특이 사항 
- ~~피그마를 보니 전체 참여자 수, 각각의 참여자 수 를 추가로 제공해줘야 할 필요가 있어보임
( 프론트 담당자 분과 이야기 후 다음 commit에 추가예정)~~
 
### #️⃣ Issue Link - #86 
