### PR TITLE
[Feature] GET /v1/notices 공지사항 글 목록#61

### DIFF
--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -36,9 +36,7 @@ public class NoticeController {
 
     @GetMapping
     public ResponseEntity<ResponseDTO<List<NoticeListResponse>>> getNoticeList() {
-
         ResponseDTO<List<NoticeListResponse>> response = noticeFacade.getNoticeList();
-
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
 
     }

--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -2,13 +2,16 @@ package com.yanolja_final.domain.notice.controller;
 
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
 import com.yanolja_final.domain.notice.facade.NoticeFacade;
 import com.yanolja_final.global.util.ResponseDTO;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +32,14 @@ public class NoticeController {
             registerNoticeRequest);
 
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<NoticeListResponse>>> getNoticeList() {
+
+        ResponseDTO<List<NoticeListResponse>> response = noticeFacade.getNoticeList();
+
+        return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
@@ -1,0 +1,28 @@
+package com.yanolja_final.domain.notice.dto.response;
+
+import com.yanolja_final.domain.notice.entity.Notice;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record NoticeListResponse(
+
+    Long noticeId,
+    String title,
+    String createdAt
+
+) {
+    public static NoticeListResponse fromNotice(Notice notice) {
+        return new NoticeListResponse(
+            notice.getId(),
+            notice.getTitle(),
+            notice.getFormattedDate()
+        );
+    }
+
+    public static List<NoticeListResponse> fromNotices(List<Notice> notices) {
+        return notices.stream()
+            .map(NoticeListResponse::fromNotice)
+            .collect(Collectors.toList());
+
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
@@ -1,8 +1,7 @@
 package com.yanolja_final.domain.notice.dto.response;
 
 import com.yanolja_final.domain.notice.entity.Notice;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+
 
 public record RegisterNoticeResponse(
     Long noticeId,
@@ -20,14 +19,9 @@ public record RegisterNoticeResponse(
         return new RegisterNoticeResponse(
             notice.getId(),
             notice.getTitle(),
-            getFormattedDate(notice.getCreatedAt()),
+            notice.getFormattedDate(),
             splitContent
         );
-    }
-
-    public static String getFormattedDate(LocalDateTime createdAt) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        return createdAt.format(formatter);
     }
 }
 

--- a/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
+++ b/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,5 +31,10 @@ public class Notice extends BaseTimeEntity {
     public Notice(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public String getFormattedDate() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return this.createdAt.format(formatter);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -24,6 +24,7 @@ public class NoticeFacade {
         return registerNoticeResponse;
     }
 
+
     public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
 
         ResponseDTO<List<NoticeListResponse>> noticeListResponse = noticeService.getNoticeList();

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -2,9 +2,11 @@ package com.yanolja_final.domain.notice.facade;
 
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
 import com.yanolja_final.domain.notice.service.NoticeService;
 import com.yanolja_final.global.util.ResponseDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,4 +23,11 @@ public class NoticeFacade {
             .registerNotice(registerNoticeRequest);
         return registerNoticeResponse;
     }
+
+    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
+
+        ResponseDTO<List<NoticeListResponse>> noticeListResponse = noticeService.getNoticeList();
+        return noticeListResponse;
+    }
+
 }

--- a/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
@@ -1,10 +1,12 @@
 package com.yanolja_final.domain.notice.service;
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
 import com.yanolja_final.domain.notice.entity.Notice;
 import com.yanolja_final.domain.notice.repository.NoticeRepository;
 import com.yanolja_final.global.util.ResponseDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,4 +25,12 @@ public class NoticeService {
         return ResponseDTO.okWithData(RegisterNoticeResponse.from(newNotice));
 
     }
+
+    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
+        List<Notice> notices = noticeRepository.findAll();
+        List<NoticeListResponse> noticeListResponses = NoticeListResponse.fromNotices(notices);
+
+        return ResponseDTO.okWithData(noticeListResponses);
+    }
+
 }


### PR DESCRIPTION
## ⭐ Postman / H2 console 사진 첨부

![20240105_NoticeList](https://github.com/yanolja-finalproject/Backend/assets/129931655/9cd55653-57b8-4289-a9a7-661e02663553)
![20240105_NoticeList_H2](https://github.com/yanolja-finalproject/Backend/assets/129931655/eedae488-6198-46ea-85cf-cf7789d8c5d8)


API design ResponseBody의 형식과 같습니다.
(전부 조회 되는지 확인하기 위해서 마지막 조회 사진 및 h2에 저장된 사진으로 첨부)

### 📑 주요 작성/변경사항

*공지사항 글 목록 조회 기능 추가 / 

*[refactor] String("yyyy-MM-dd")의 타입으로 변환하는 method: getFormattedDate() 활용성 높이기 위해 위치 변경.
(RegisterNoticeResponse->Notice)

