### PR TITLE
[Feature] GET /v1/notices/{id} 공지사항 상세보기#71

### DIFF
--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -32,25 +32,22 @@ public class NoticeController {
     ) {
         ResponseDTO<NoticeResponse> response = noticeFacade.registerNotice(
             registerNoticeRequest);
-
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
     }
+
 
     @GetMapping
     public ResponseEntity<ResponseDTO<List<NoticeListResponse>>> getNoticeList() {
-
         ResponseDTO<List<NoticeListResponse>> response = noticeFacade.getNoticeList();
-
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
-
     }
+
 
     @GetMapping("/{noticeId}")
     public ResponseEntity<ResponseDTO<NoticeResponse>> getSpecificNotice(
         @PathVariable Long noticeId
     ) {
         ResponseDTO<NoticeResponse> response = noticeFacade.getSpecificNotice(noticeId);
-
         return ResponseEntity.status(HttpStatusCode.valueOf(response.getCode())).body(response);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -3,15 +3,17 @@ package com.yanolja_final.domain.notice.controller;
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
 import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
-import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
+import com.yanolja_final.domain.notice.dto.response.NoticeResponse;
 import com.yanolja_final.domain.notice.facade.NoticeFacade;
 import com.yanolja_final.global.util.ResponseDTO;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -25,10 +27,10 @@ public class NoticeController {
     private final NoticeFacade noticeFacade;
 
     @PostMapping
-    public ResponseEntity<ResponseDTO<RegisterNoticeResponse>> createNotice(
+    public ResponseEntity<ResponseDTO<NoticeResponse>> createNotice(
         @Valid @RequestBody RegisterNoticeRequest registerNoticeRequest
     ) {
-        ResponseDTO<RegisterNoticeResponse> response = noticeFacade.registerNotice(
+        ResponseDTO<NoticeResponse> response = noticeFacade.registerNotice(
             registerNoticeRequest);
 
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
@@ -41,5 +43,14 @@ public class NoticeController {
 
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
 
+    }
+
+    @GetMapping("/{noticeId}")
+    public ResponseEntity<ResponseDTO<NoticeResponse>> getSpecificNotice(
+        @PathVariable Long noticeId
+    ) {
+        ResponseDTO<NoticeResponse> response = noticeFacade.getSpecificNotice(noticeId);
+
+        return ResponseEntity.status(HttpStatusCode.valueOf(response.getCode())).body(response);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -2,13 +2,16 @@ package com.yanolja_final.domain.notice.controller;
 
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
 import com.yanolja_final.domain.notice.facade.NoticeFacade;
 import com.yanolja_final.global.util.ResponseDTO;
 import jakarta.validation.Valid;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,5 +32,14 @@ public class NoticeController {
             registerNoticeRequest);
 
         return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+    }
+
+    @GetMapping
+    public ResponseEntity<ResponseDTO<List<NoticeListResponse>>> getNoticeList() {
+
+        ResponseDTO<List<NoticeListResponse>> response = noticeFacade.getNoticeList();
+
+        return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
@@ -1,0 +1,28 @@
+package com.yanolja_final.domain.notice.dto.response;
+
+import com.yanolja_final.domain.notice.entity.Notice;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record NoticeListResponse(
+
+    Long noticeId,
+    String title,
+    String createdAt
+
+) {
+    public static NoticeListResponse fromNotice(Notice notice) {
+        return new NoticeListResponse(
+            notice.getId(),
+            notice.getTitle(),
+            notice.getFormattedDate()
+        );
+    }
+
+    public static List<NoticeListResponse> fromNotices(List<Notice> notices) {
+        return notices.stream()
+            .map(NoticeListResponse::fromNotice)
+            .collect(Collectors.toList());
+
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
@@ -3,7 +3,7 @@ package com.yanolja_final.domain.notice.dto.response;
 import com.yanolja_final.domain.notice.entity.Notice;
 
 
-public record RegisterNoticeResponse(
+public record NoticeResponse(
     Long noticeId,
     String title,
     String createdAt,
@@ -11,12 +11,11 @@ public record RegisterNoticeResponse(
 
 ) {
 
-
-    public static RegisterNoticeResponse from(Notice notice) {
+    public static NoticeResponse fromNotice(Notice notice) {
 
         String[] splitContent = notice.getContent().split("\n");
 
-        return new RegisterNoticeResponse(
+        return new NoticeResponse(
             notice.getId(),
             notice.getTitle(),
             notice.getFormattedDate(),

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/RegisterNoticeResponse.java
@@ -1,8 +1,7 @@
 package com.yanolja_final.domain.notice.dto.response;
 
 import com.yanolja_final.domain.notice.entity.Notice;
-import java.time.LocalDateTime;
-import java.time.format.DateTimeFormatter;
+
 
 public record RegisterNoticeResponse(
     Long noticeId,
@@ -20,14 +19,9 @@ public record RegisterNoticeResponse(
         return new RegisterNoticeResponse(
             notice.getId(),
             notice.getTitle(),
-            getFormattedDate(notice.getCreatedAt()),
+            notice.getFormattedDate(),
             splitContent
         );
-    }
-
-    public static String getFormattedDate(LocalDateTime createdAt) {
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-        return createdAt.format(formatter);
     }
 }
 

--- a/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
+++ b/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import java.time.format.DateTimeFormatter;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,5 +31,10 @@ public class Notice extends BaseTimeEntity {
     public Notice(String title, String content) {
         this.title = title;
         this.content = content;
+    }
+
+    public String getFormattedDate() {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+        return this.createdAt.format(formatter);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/yanolja_final/domain/notice/exception/NoticeNotFoundException.java
@@ -1,0 +1,13 @@
+package com.yanolja_final.domain.notice.exception;
+
+import com.yanolja_final.global.exception.ApplicationException;
+import com.yanolja_final.global.exception.ErrorCode;
+
+public class NoticeNotFoundException extends ApplicationException {
+
+    private static final ErrorCode ERROR_CODE = ErrorCode.NOTICE_NOT_FOUND;
+
+    public NoticeNotFoundException() { super(ERROR_CODE);}
+
+
+}

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -3,7 +3,7 @@ package com.yanolja_final.domain.notice.facade;
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
 import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
-import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
+import com.yanolja_final.domain.notice.dto.response.NoticeResponse;
 import com.yanolja_final.domain.notice.service.NoticeService;
 import com.yanolja_final.global.util.ResponseDTO;
 import java.util.List;
@@ -16,11 +16,10 @@ public class NoticeFacade {
 
     private final NoticeService noticeService;
 
-    public ResponseDTO<RegisterNoticeResponse> registerNotice(
-        RegisterNoticeRequest registerNoticeRequest) {
+    public ResponseDTO<NoticeResponse> registerNotice(
+        RegisterNoticeRequest request) {
 
-        ResponseDTO<RegisterNoticeResponse> registerNoticeResponse = noticeService
-            .registerNotice(registerNoticeRequest);
+        ResponseDTO<NoticeResponse> registerNoticeResponse = noticeService.registerNotice(request);
         return registerNoticeResponse;
     }
 
@@ -30,4 +29,10 @@ public class NoticeFacade {
         return noticeListResponse;
     }
 
+    public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
+
+        ResponseDTO<NoticeResponse> specificNotice = noticeService.getSpecificNotice(noticeId);
+        return specificNotice;
+
+    }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -18,21 +18,19 @@ public class NoticeFacade {
 
     public ResponseDTO<NoticeResponse> registerNotice(
         RegisterNoticeRequest request) {
-
         ResponseDTO<NoticeResponse> registerNoticeResponse = noticeService.registerNotice(request);
         return registerNoticeResponse;
     }
 
-    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
 
+    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
         ResponseDTO<List<NoticeListResponse>> noticeListResponse = noticeService.getNoticeList();
         return noticeListResponse;
     }
 
-    public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
 
+    public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
         ResponseDTO<NoticeResponse> specificNotice = noticeService.getSpecificNotice(noticeId);
         return specificNotice;
-
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -2,9 +2,11 @@ package com.yanolja_final.domain.notice.facade;
 
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
 import com.yanolja_final.domain.notice.service.NoticeService;
 import com.yanolja_final.global.util.ResponseDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -21,4 +23,11 @@ public class NoticeFacade {
             .registerNotice(registerNoticeRequest);
         return registerNoticeResponse;
     }
+
+    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
+
+        ResponseDTO<List<NoticeListResponse>> noticeListResponse = noticeService.getNoticeList();
+        return noticeListResponse;
+    }
+
 }

--- a/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
@@ -1,10 +1,12 @@
 package com.yanolja_final.domain.notice.service;
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
+import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
 import com.yanolja_final.domain.notice.entity.Notice;
 import com.yanolja_final.domain.notice.repository.NoticeRepository;
 import com.yanolja_final.global.util.ResponseDTO;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -23,4 +25,12 @@ public class NoticeService {
         return ResponseDTO.okWithData(RegisterNoticeResponse.from(newNotice));
 
     }
+
+    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
+        List<Notice> notices = noticeRepository.findAll();
+        List<NoticeListResponse> noticeListResponses = NoticeListResponse.fromNotices(notices);
+
+        return ResponseDTO.okWithData(noticeListResponses);
+    }
+
 }

--- a/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
@@ -2,8 +2,9 @@ package com.yanolja_final.domain.notice.service;
 
 import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
 import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
-import com.yanolja_final.domain.notice.dto.response.RegisterNoticeResponse;
+import com.yanolja_final.domain.notice.dto.response.NoticeResponse;
 import com.yanolja_final.domain.notice.entity.Notice;
+import com.yanolja_final.domain.notice.exception.NoticeNotFoundException;
 import com.yanolja_final.domain.notice.repository.NoticeRepository;
 import com.yanolja_final.global.util.ResponseDTO;
 import java.util.List;
@@ -16,13 +17,13 @@ public class NoticeService {
 
     private final NoticeRepository noticeRepository;
 
-    public ResponseDTO<RegisterNoticeResponse> registerNotice(
+    public ResponseDTO<NoticeResponse> registerNotice(
         RegisterNoticeRequest registerNoticeRequest) {
 
         Notice notice = registerNoticeRequest.toEntity();
         Notice newNotice = noticeRepository.save(notice);
 
-        return ResponseDTO.okWithData(RegisterNoticeResponse.from(newNotice));
+        return ResponseDTO.okWithData(NoticeResponse.fromNotice(newNotice));
 
     }
 
@@ -31,6 +32,16 @@ public class NoticeService {
         List<NoticeListResponse> noticeListResponses = NoticeListResponse.fromNotices(notices);
 
         return ResponseDTO.okWithData(noticeListResponses);
+    }
+
+    public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
+        Notice notice = noticeRepository.findById(noticeId)
+            .orElseThrow(() -> new NoticeNotFoundException());
+
+        NoticeResponse specificNoticeResponse = NoticeResponse.fromNotice(notice);
+
+        return ResponseDTO.okWithData(specificNoticeResponse);
+
     }
 
 }

--- a/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
@@ -27,6 +27,9 @@ public enum ErrorCode {
     // WISH
     WISH_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 찜ID 입니다."),
 
+    //NOTICE
+    NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 공지사항ID 입니다."),
+
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");
 


### PR DESCRIPTION
## ⭐ 테스트 결과 사진

![20240105_specificNoticeId1](https://github.com/yanolja-finalproject/Backend/assets/129931655/51e6442f-09b4-49cb-89f8-111b4150105e)
![20240105_specificNoticeId2](https://github.com/yanolja-finalproject/Backend/assets/129931655/e38d4c14-53f0-4f67-8cf4-67b8e8369f7d)
![20240105_specificNoticeId3](https://github.com/yanolja-finalproject/Backend/assets/129931655/a01e94b4-fadf-4d3c-bfbe-c6547244f3fc)
![20240105_specificNoticeId4_404NotFound](https://github.com/yanolja-finalproject/Backend/assets/129931655/2b29a533-7042-493c-89d6-9596b2c94ce7)



### 📑 주요 작성/변경사항

-  공지 상세 조회 API 

- RegisterNoticeResponse -> NoticeResponse로 통일 : 공지 상세 조회와 공지 등록에서 동일한 ResponseBody 응답 구조를 사용하여 클래스 명의 혼란을 방지하기 위해 변경. 
-  Request와 Response의 from/to 메서드 명을 from/to + Entity 의 이름으로 변경 - fromNotice / toNotice



