### PR TITLE
[Sql] Package 관련 모든 테이블에 대한 sql문 작성

### DIFF
--- a/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
@@ -13,6 +13,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import java.time.LocalTime;
@@ -29,16 +30,16 @@ public class Package extends BaseEntity {
     @Id
     private Long id;
 
-    @Column(nullable = false)
+    @Column
     private LocalTime departureTime;
 
-    @Column(nullable = false)
+    @Column
     private LocalTime endTime;
 
-    @OneToOne
+    @ManyToOne
     private Nation nation;
 
-    @OneToOne
+    @ManyToOne
     private Continent continent;
 
     @Column(length = 100, nullable = false)

--- a/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
@@ -72,6 +72,9 @@ public class Package extends BaseEntity {
     private Integer purchasedCount = 0;
 
     @Column(nullable = false)
+    private Integer monthlyPurchasedCount = 0;
+
+    @Column(nullable = false)
     private Integer shoppingCount = 0;
 
     @Column(columnDefinition = "TEXT", nullable = false)

--- a/src/main/java/com/yanolja_final/domain/packages/entity/PackageImage.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/PackageImage.java
@@ -18,6 +18,9 @@ public class PackageImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private Long packageId;
+
     @Column(length = 300, nullable = false)
     private String imageUrl;
 }

--- a/src/main/java/com/yanolja_final/domain/packages/entity/PackageIntroImage.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/PackageIntroImage.java
@@ -18,6 +18,9 @@ public class PackageIntroImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @Column(nullable = false)
+    private Long packageId;
+
     @Column(length = 300, nullable = false)
     private String imageUrl;
 }


### PR DESCRIPTION
closes #49 
## ⭐ 개요

### 종류
- [X] New Feature
- [ ] Bug Fix
- [ ] CI/CD
- [X] Setup

### 📑 주요 작성/변경사항

- Package 관련 크롤링 데이터를 삽입하는 모든 쿼리문을 담은 data.sql을 만들었습니다
- 데이터의 형식과 맞지 않는 부분이 있어 Package Entity 일부 코드가 수정되었습니다
- Figma 기획에 월별 구매수를 필요로 하는 부분이 있어 Package 테이블에 monthly_purchased_count를 추가했습니다 (ERD에도 반영 완료)

### 💡 특이 사항

- 코드는 사실상 바뀐게 크게 없습니다.
- 약 700개 패키지 데이터를 전부 넣으니 Github actions CI가 고장나서 전체의 20% 정도만 넣었습니다