### PR TITLE
Feature/98 _ 20240108 Entity 변경 이후 변경점에 맞추어 공지사항 등록, 목록 및 상세 조회 API 수정 및 테스트

### DIFF
--- a/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
@@ -2,21 +2,32 @@ package com.yanolja_final.domain.notice.dto.request;
 
 import com.yanolja_final.domain.notice.entity.Notice;
 import jakarta.validation.constraints.NotNull;
+import java.util.Arrays;
+import java.util.stream.Collectors;
+import javax.print.DocFlavor.STRING;
+import org.aspectj.weaver.ast.Not;
 
 public record RegisterNoticeRequest(
     @NotNull
     String title,
     @NotNull
-    String[] content
+    String[] content,
+    @NotNull
+    String[] categories
 ) {
 
     public Notice toEntity() {
-
-        String splitContent = String.join("\n", content);
+        String splitContent = Arrays.stream(content)
+            .map(String::trim)
+            .collect(Collectors.joining("\n"));
+        String splitCategories = Arrays.stream(categories)
+            .map(String::trim)
+            .collect(Collectors.joining(","));
 
         return Notice.builder()
             .title(title)
             .content(splitContent)
+            .categories(splitCategories)
             .build();
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
@@ -15,7 +15,6 @@ public record RegisterNoticeRequest(
     @NotNull
     String[] categories
 ) {
-
     public Notice toEntity() {
         String splitContent = Arrays.stream(content)
             .map(String::trim)

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public record NoticeListResponse(
-
     Long noticeId,
     String title,
     String createdAt,

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
@@ -8,14 +8,18 @@ public record NoticeListResponse(
 
     Long noticeId,
     String title,
-    String createdAt
+    String createdAt,
+    String[] categories
 
 ) {
     public static NoticeListResponse fromNotice(Notice notice) {
+        String[] splitCategories = notice.getCategories().split(",");
+
         return new NoticeListResponse(
             notice.getId(),
             notice.getTitle(),
-            notice.getFormattedDate()
+            notice.getFormattedDate(),
+            splitCategories
         );
     }
 
@@ -23,6 +27,5 @@ public record NoticeListResponse(
         return notices.stream()
             .map(NoticeListResponse::fromNotice)
             .collect(Collectors.toList());
-
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
@@ -12,7 +12,6 @@ public record NoticeResponse(
 ) {
 
     public static NoticeResponse fromNotice(Notice notice) {
-
         String[] splitContent = notice.getContent().split("\n");
         String[] splitCategories = notice.getCategories().split(",");
 

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
@@ -7,20 +7,21 @@ public record NoticeResponse(
     Long noticeId,
     String title,
     String createdAt,
-    String[] content
-
+    String[] content,
+    String[] categories
 ) {
-
 
     public static NoticeResponse fromNotice(Notice notice) {
 
         String[] splitContent = notice.getContent().split("\n");
+        String[] splitCategories = notice.getCategories().split(",");
 
         return new NoticeResponse(
             notice.getId(),
             notice.getTitle(),
             notice.getFormattedDate(),
-            splitContent
+            splitContent,
+            splitCategories
         );
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
+++ b/src/main/java/com/yanolja_final/domain/notice/entity/Notice.java
@@ -31,9 +31,10 @@ public class Notice extends BaseEntity {
     private String categories;
 
     @Builder
-    public Notice(String title, String content) {
+    public Notice(String title, String content, String categories) {
         this.title = title;
         this.content = content;
+        this.categories = categories;
     }
 
     public String getFormattedDate() {

--- a/src/main/java/com/yanolja_final/domain/notice/exception/NoticeNotFoundException.java
+++ b/src/main/java/com/yanolja_final/domain/notice/exception/NoticeNotFoundException.java
@@ -8,5 +8,4 @@ public class NoticeNotFoundException extends ApplicationException {
     private static final ErrorCode ERROR_CODE = ErrorCode.NOTICE_NOT_FOUND;
 
     public NoticeNotFoundException() { super(ERROR_CODE); }
-
 }

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -21,12 +21,10 @@ public class NoticeFacade {
         return response;
     }
 
-
     public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
         ResponseDTO<List<NoticeListResponse>> response = noticeService.getNoticeList();
         return response;
     }
-
 
     public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
         ResponseDTO<NoticeResponse> response = noticeService.getSpecificNotice(noticeId);

--- a/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
@@ -26,15 +26,15 @@ public class NoticeService {
 
     public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
         List<Notice> notices = noticeRepository.findAll();
-        List<NoticeListResponse> noticeListResponses = NoticeListResponse.fromNotices(notices);
-        return ResponseDTO.okWithData(noticeListResponses);
+        List<NoticeListResponse> response = NoticeListResponse.fromNotices(notices);
+        return ResponseDTO.okWithData(response);
     }
 
 
     public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
             .orElseThrow(() -> new NoticeNotFoundException());
-        NoticeResponse specificNoticeResponse = NoticeResponse.fromNotice(notice);
-        return ResponseDTO.okWithData(specificNoticeResponse);
+        NoticeResponse response = NoticeResponse.fromNotice(notice);
+        return ResponseDTO.okWithData(response);
     }
 }


### PR DESCRIPTION
## ⭐ 수정 이후 테스트 결과 사진
<공지사항 등록>
![Notice_updatedEntity_register](https://github.com/yanolja-finalproject/Backend/assets/129931655/8a51eef8-7979-4160-ada1-628e5a07b6c4)

<공지사항 목록 조회>
![Notice_updatedEntity_getNoticeList](https://github.com/yanolja-finalproject/Backend/assets/129931655/5455c1e2-376b-42eb-9904-47fc01d34e31)

<공지사항 상세 조회>
![Notice_updatedEntity_getSpecific4](https://github.com/yanolja-finalproject/Backend/assets/129931655/11d3d5da-77c8-4755-8b10-9051382e30c1)

<에러처리 _ 404 NOT_FOUND >
![Notice_updatedEntity_getSpecific_404 NotFound](https://github.com/yanolja-finalproject/Backend/assets/129931655/e593b6f6-72e6-41f6-bb35-c4a17355aadb)


### 💡 특이 사항 
* 01/08 Entity 변경 이후의 기준에 맞춰 수정하였습니다. (사진 위에 각각 기능 명)
* 기존 Notice 공지사항에 적용하지 못했던 trim  -> String[] categories와 String[] content에 적용 하였습니다.
* 기존에 처리하지 못했던 줄바꿈 제거나 인스턴스 이름 변경 있습니다.