### PR TITLE
[Feature] DTO Validation 실패 시 어떤 정보가 잘못됐는지 메시지 더 자세히 출력

### DIFF
--- a/src/main/java/com/yanolja_final/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/yanolja_final/global/exception/GlobalExceptionRestAdvice.java
@@ -1,11 +1,20 @@
 package com.yanolja_final.global.exception;
 
 import com.yanolja_final.global.util.ResponseDTO;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.NestedExceptionUtils;
 import org.springframework.dao.DataAccessException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.FieldError;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
@@ -22,12 +31,34 @@ public class GlobalExceptionRestAdvice {
     }
 
     @ExceptionHandler
-    public ResponseEntity<ResponseDTO<Void>> bindException(BindException e) {
-        log.error(e.getMessage(), e);
-        return ResponseEntity
-            .status(HttpStatus.BAD_REQUEST)
-            .body(ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST,
-                e.getBindingResult().getAllErrors().get(0).getDefaultMessage()));
+    public ResponseDTO<Void> validationException(BindException e) {
+        log.warn("[ValidationException] Message = {}",
+            NestedExceptionUtils.getMostSpecificCause(e).getMessage());
+
+        BindingResult bindingResult = e.getBindingResult();
+        List<FieldError> fieldErrors = getSortedFieldErrors(bindingResult);
+
+        String response = "[Request error] "
+            + fieldErrors.stream()
+            .map(fieldError -> String.format("%s (%s=%s)",
+                    fieldError.getDefaultMessage(),
+                    fieldError.getField(),
+                    fieldError.getRejectedValue()
+                )
+            ).collect(Collectors.joining());
+        return ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST, response);
+    }
+
+    private List<FieldError> getSortedFieldErrors(BindingResult bindingResult) {
+        List<String> declaredFields = Arrays.stream(
+                Objects.requireNonNull(bindingResult.getTarget()).getClass().getDeclaredFields())
+            .map(Field::getName)
+            .toList();
+
+        return bindingResult.getFieldErrors().stream()
+            .filter(fieldError -> declaredFields.contains(fieldError.getField()))
+            .sorted(Comparator.comparingInt(fe -> declaredFields.indexOf(fe.getField())))
+            .collect(Collectors.toList());
     }
 
     @ExceptionHandler

--- a/src/main/java/com/yanolja_final/global/exception/GlobalExceptionRestAdvice.java
+++ b/src/main/java/com/yanolja_final/global/exception/GlobalExceptionRestAdvice.java
@@ -31,21 +31,20 @@ public class GlobalExceptionRestAdvice {
     }
 
     @ExceptionHandler
-    public ResponseDTO<Void> validationException(BindException e) {
-        log.warn("[ValidationException] Message = {}",
+    public ResponseDTO<Void> bindException(BindException e) {
+        log.warn("[bindException] Message = {}",
             NestedExceptionUtils.getMostSpecificCause(e).getMessage());
 
         BindingResult bindingResult = e.getBindingResult();
         List<FieldError> fieldErrors = getSortedFieldErrors(bindingResult);
 
-        String response = "[Request error] "
-            + fieldErrors.stream()
+        String response = fieldErrors.stream()
             .map(fieldError -> String.format("%s (%s=%s)",
                     fieldError.getDefaultMessage(),
                     fieldError.getField(),
                     fieldError.getRejectedValue()
                 )
-            ).collect(Collectors.joining());
+            ).collect(Collectors.joining(", "));
         return ResponseDTO.errorWithMessage(HttpStatus.BAD_REQUEST, response);
     }
 


### PR DESCRIPTION
closes #116
## ⭐ 개요

### 종류
- [X] New Feature

### 📑 주요 작성/변경사항
- [X] DTO Validation 실패 시 메시지가 딱 하나만 출력되는 부분을 모두 출력되게 하고, 값이 어떻게 들어왔는지 보이도록 하였습니다

**개선 전**
```java
{
    "code": 400,
    "message": "사용자 이름을 입력해 주세요."
}
```

**개선 후**
```java
{
    "code": 400,
    "message": "이메일을 입력해 주세요. (email=null), 사용자 이름을 입력해 주세요. (username=null), 비밀 번호를 입력해 주세요. (password=null), 이용약관 동의 여부를 체크해 주세요. (isTermsAgreed=null)"
}
```