### PR TITLE
[Feature] GET /v1/advertisements/{id} 광고구좌 조회

### DIFF
--- a/src/main/java/com/yanolja_final/domain/advertisement/controller/AdvertisementController.java
+++ b/src/main/java/com/yanolja_final/domain/advertisement/controller/AdvertisementController.java
@@ -1,11 +1,13 @@
 package com.yanolja_final.domain.advertisement.controller;
 
+import com.yanolja_final.domain.advertisement.dto.response.AdDetailResponse;
 import com.yanolja_final.domain.advertisement.dto.response.AdListItemResponse;
 import com.yanolja_final.domain.advertisement.facade.AdFacade;
 import com.yanolja_final.global.util.ResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -20,5 +22,13 @@ public class AdvertisementController {
     public ResponseDTO<List<AdListItemResponse>> getAdList() {
         List<AdListItemResponse> list = adFacade.getList();
         return ResponseDTO.okWithData(list);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseDTO<AdDetailResponse> getAdDetail(
+        @PathVariable Long id
+    ) {
+        AdDetailResponse detail = adFacade.getDetail(id);
+        return ResponseDTO.okWithData(detail);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/advertisement/dto/response/AdDetailResponse.java
+++ b/src/main/java/com/yanolja_final/domain/advertisement/dto/response/AdDetailResponse.java
@@ -1,0 +1,23 @@
+package com.yanolja_final.domain.advertisement.dto.response;
+
+import com.yanolja_final.domain.advertisement.entity.Advertisement;
+import com.yanolja_final.domain.advertisement.entity.AdvertisementImage;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record AdDetailResponse(
+    Long adId,
+    String name,
+    List<String> imageUrls,
+    List<AdPackageResponse> packages
+) {
+
+    public static AdDetailResponse from(Advertisement ad) {
+        return new AdDetailResponse(
+            ad.getId(),
+            ad.getName(),
+            ad.getImages().stream().map(AdvertisementImage::getImageUrl).collect(Collectors.toList()),
+            ad.getPackages().stream().map(AdPackageResponse::from).collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/advertisement/dto/response/AdPackageResponse.java
+++ b/src/main/java/com/yanolja_final/domain/advertisement/dto/response/AdPackageResponse.java
@@ -1,0 +1,22 @@
+package com.yanolja_final.domain.advertisement.dto.response;
+
+import com.yanolja_final.domain.packages.entity.Package;
+
+public record AdPackageResponse(
+    Long packageId,
+    String imageUrl,
+    String transportation,
+    String title,
+    int minPrice
+) {
+
+    public static AdPackageResponse from(Package aPackage) {
+        return new AdPackageResponse(
+            aPackage.getId(),
+            aPackage.getThumbnailImageUrl(),
+            aPackage.getTransportation(),
+            aPackage.getTitle(),
+            aPackage.getMinPrice()
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/advertisement/exception/AdvertisementNotFound.java
+++ b/src/main/java/com/yanolja_final/domain/advertisement/exception/AdvertisementNotFound.java
@@ -1,0 +1,11 @@
+package com.yanolja_final.domain.advertisement.exception;
+
+import com.yanolja_final.global.exception.ApplicationException;
+import com.yanolja_final.global.exception.ErrorCode;
+
+public class AdvertisementNotFound extends ApplicationException {
+
+    public AdvertisementNotFound() {
+        super(ErrorCode.ADVERTISEMENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/advertisement/facade/AdFacade.java
+++ b/src/main/java/com/yanolja_final/domain/advertisement/facade/AdFacade.java
@@ -1,5 +1,6 @@
 package com.yanolja_final.domain.advertisement.facade;
 
+import com.yanolja_final.domain.advertisement.dto.response.AdDetailResponse;
 import com.yanolja_final.domain.advertisement.dto.response.AdListItemResponse;
 import com.yanolja_final.domain.advertisement.service.AdService;
 import java.util.List;
@@ -14,5 +15,9 @@ public class AdFacade {
 
     public List<AdListItemResponse> getList() {
         return adService.getList();
+    }
+
+    public AdDetailResponse getDetail(Long id) {
+        return adService.getDetail(id);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/advertisement/service/AdService.java
+++ b/src/main/java/com/yanolja_final/domain/advertisement/service/AdService.java
@@ -1,7 +1,9 @@
 package com.yanolja_final.domain.advertisement.service;
 
+import com.yanolja_final.domain.advertisement.dto.response.AdDetailResponse;
 import com.yanolja_final.domain.advertisement.dto.response.AdListItemResponse;
 import com.yanolja_final.domain.advertisement.entity.Advertisement;
+import com.yanolja_final.domain.advertisement.exception.AdvertisementNotFound;
 import com.yanolja_final.domain.advertisement.repository.AdRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -21,5 +23,10 @@ public class AdService {
         return ads.stream()
             .map(AdListItemResponse::from)
             .collect(Collectors.toList());
+    }
+
+    public AdDetailResponse getDetail(Long id) {
+        Advertisement ad = adRepository.findById(id).orElseThrow(AdvertisementNotFound::new);
+        return AdDetailResponse.from(ad);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
@@ -111,6 +111,7 @@ public class Package extends BaseEntity {
 
     public int getMinPrice() {
         return availableDates.stream()
+            .filter(PackageDepartureOption::isExpired)
             .mapToInt(PackageDepartureOption::getAdultPrice)
             .min()
             .orElse(-1);

--- a/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
@@ -7,21 +7,17 @@ import jakarta.persistence.ConstraintMode;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
 import jakarta.persistence.ForeignKey;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.JoinTable;
 import jakarta.persistence.ManyToMany;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
-import jakarta.persistence.OneToOne;
 import java.time.LocalTime;
 import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @NoArgsConstructor
@@ -111,7 +107,7 @@ public class Package extends BaseEntity {
 
     public int getMinPrice() {
         return availableDates.stream()
-            .filter(PackageDepartureOption::isExpired)
+            .filter(PackageDepartureOption::isNotExpired)
             .mapToInt(PackageDepartureOption::getAdultPrice)
             .min()
             .orElse(-1);

--- a/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Set;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Entity
 @NoArgsConstructor
@@ -28,6 +29,7 @@ import lombok.NoArgsConstructor;
 public class Package extends BaseEntity {
 
     @Id
+    @Column
     private Long id;
 
     @Column
@@ -82,9 +84,11 @@ public class Package extends BaseEntity {
     private String schedules;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "package_id")
     private List<PackageDepartureOption> availableDates;
 
     @OneToMany(fetch = FetchType.LAZY, cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "package_id")
     private List<PackageImage> images;
 
     @ManyToMany(fetch = FetchType.LAZY)
@@ -99,5 +103,16 @@ public class Package extends BaseEntity {
 
     public String getNationName() {
         return this.nation.getName();
+    }
+
+    public String getThumbnailImageUrl() {
+        return this.images.get(0).getImageUrl();
+    }
+
+    public int getMinPrice() {
+        return availableDates.stream()
+            .mapToInt(PackageDepartureOption::getAdultPrice)
+            .min()
+            .orElse(-1);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/entity/PackageDepartureOption.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/PackageDepartureOption.java
@@ -42,7 +42,7 @@ public class PackageDepartureOption extends BaseEntity {
 
     private Integer maxReservationCount;
 
-    public boolean isExpired() {
-        return departureDate.isBefore(LocalDate.now());
+    public boolean isNotExpired() {
+        return !departureDate.isBefore(LocalDate.now());
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/entity/PackageDepartureOption.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/PackageDepartureOption.java
@@ -41,4 +41,8 @@ public class PackageDepartureOption extends BaseEntity {
     private Integer minReservationCount;
 
     private Integer maxReservationCount;
+
+    public boolean isExpired() {
+        return departureDate.isBefore(LocalDate.now());
+    }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/entity/PackageImage.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/PackageImage.java
@@ -18,7 +18,7 @@ public class PackageImage extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(name = "package_id", nullable = false)
     private Long packageId;
 
     @Column(length = 300, nullable = false)

--- a/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
@@ -35,8 +35,11 @@ public enum ErrorCode {
     UNAUTHORIZED_REVIEW_ACCESS(HttpStatus.FORBIDDEN, "리뷰 작성 권한이 없습니다."),
     REVIEW_ALREADY_REGISTERED(HttpStatus.BAD_REQUEST, "이미 리뷰를 작성하였습니다."),
 
-    //NOTICE
+    // NOTICE
     NOTICE_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 공지사항ID 입니다."),
+
+    // ADVERTISEMENT
+    ADVERTISEMENT_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 패키지입니다."),
 
     // 5xx
     INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 에러");


### PR DESCRIPTION
closes #37 

## ⭐ 개요

### 종류
- [X] New Feature

### 📑 주요 작성/변경사항
- GET /v1/advertisements/{id} 광고구좌 상세조회 구현

### 💡 특이 사항 
- Package 엔티티의 availableDates, images가 제대로 안 불러와지는 이슈가 있었음
  - 확인해보니 무엇과 무엇을 join 해야하는지 hibernate가 알 수 없어서 다대다테이블을 맘대로 만들고 있었음
  - `@JoinColumn`을 통해 명시적으로 조인해주니 해결
- **minPrice** 구현했습니다 @ghrltjdtprbs @windowM 

### 스크린샷
<img width="870" alt="image" src="https://github.com/yanolja-finalproject/Backend/assets/33937365/d04be4d0-df44-4125-b8e7-351d2a1887ce">
