### PR TITLE
[refactor] 공지사항 Notice->ResponseDTO 전부 controller 에서만 사용하도록 수정

### DIFF
--- a/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
+++ b/src/main/java/com/yanolja_final/domain/notice/controller/NoticeController.java
@@ -9,7 +9,6 @@ import com.yanolja_final.global.util.ResponseDTO;
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,21 +28,21 @@ public class NoticeController {
     public ResponseEntity<ResponseDTO<NoticeResponse>> createNotice(
         @Valid @RequestBody RegisterNoticeRequest request
     ) {
-        ResponseDTO<NoticeResponse> response = noticeFacade.registerNotice(request);
-        return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+        NoticeResponse response = noticeFacade.registerNotice(request);
+        return ResponseEntity.ok(ResponseDTO.okWithData(response));
     }
 
     @GetMapping
     public ResponseEntity<ResponseDTO<List<NoticeListResponse>>> getNoticeList() {
-        ResponseDTO<List<NoticeListResponse>> response = noticeFacade.getNoticeList();
-        return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+        List<NoticeListResponse> response = noticeFacade.getNoticeList();
+        return ResponseEntity.ok(ResponseDTO.okWithData(response));
     }
 
     @GetMapping("/{noticeId}")
     public ResponseEntity<ResponseDTO<NoticeResponse>> getSpecificNotice(
         @PathVariable Long noticeId
     ) {
-        ResponseDTO<NoticeResponse> response = noticeFacade.getSpecificNotice(noticeId);
-        return ResponseEntity.status(HttpStatus.valueOf(response.getCode())).body(response);
+        NoticeResponse response = noticeFacade.getSpecificNotice(noticeId);
+        return ResponseEntity.ok(ResponseDTO.okWithData(response));
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/request/RegisterNoticeRequest.java
@@ -4,8 +4,6 @@ import com.yanolja_final.domain.notice.entity.Notice;
 import jakarta.validation.constraints.NotNull;
 import java.util.Arrays;
 import java.util.stream.Collectors;
-import javax.print.DocFlavor.STRING;
-import org.aspectj.weaver.ast.Not;
 
 public record RegisterNoticeRequest(
     @NotNull

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeListResponse.java
@@ -11,7 +11,7 @@ public record NoticeListResponse(
     String[] categories
 
 ) {
-    public static NoticeListResponse fromNotice(Notice notice) {
+    public static NoticeListResponse from(Notice notice) {
         String[] splitCategories = notice.getCategories().split(",");
 
         return new NoticeListResponse(
@@ -21,10 +21,9 @@ public record NoticeListResponse(
             splitCategories
         );
     }
-
     public static List<NoticeListResponse> fromNotices(List<Notice> notices) {
         return notices.stream()
-            .map(NoticeListResponse::fromNotice)
+            .map(NoticeListResponse::from)
             .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
+++ b/src/main/java/com/yanolja_final/domain/notice/dto/response/NoticeResponse.java
@@ -2,7 +2,6 @@ package com.yanolja_final.domain.notice.dto.response;
 
 import com.yanolja_final.domain.notice.entity.Notice;
 
-
 public record NoticeResponse(
     Long noticeId,
     String title,
@@ -10,8 +9,7 @@ public record NoticeResponse(
     String[] content,
     String[] categories
 ) {
-
-    public static NoticeResponse fromNotice(Notice notice) {
+    public static NoticeResponse from(Notice notice) {
         String[] splitContent = notice.getContent().split("\n");
         String[] splitCategories = notice.getCategories().split(",");
 

--- a/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
+++ b/src/main/java/com/yanolja_final/domain/notice/facade/NoticeFacade.java
@@ -5,7 +5,6 @@ import com.yanolja_final.domain.notice.dto.request.RegisterNoticeRequest;
 import com.yanolja_final.domain.notice.dto.response.NoticeListResponse;
 import com.yanolja_final.domain.notice.dto.response.NoticeResponse;
 import com.yanolja_final.domain.notice.service.NoticeService;
-import com.yanolja_final.global.util.ResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,18 +15,18 @@ public class NoticeFacade {
 
     private final NoticeService noticeService;
 
-    public ResponseDTO<NoticeResponse> registerNotice(RegisterNoticeRequest request) {
-        ResponseDTO<NoticeResponse> response = noticeService.registerNotice(request);
+    public NoticeResponse registerNotice(RegisterNoticeRequest request) {
+        NoticeResponse response = noticeService.registerNotice(request);
         return response;
     }
 
-    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
-        ResponseDTO<List<NoticeListResponse>> response = noticeService.getNoticeList();
+    public List<NoticeListResponse> getNoticeList() {
+        List<NoticeListResponse> response = noticeService.getNoticeList();
         return response;
     }
 
-    public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
-        ResponseDTO<NoticeResponse> response = noticeService.getSpecificNotice(noticeId);
+    public NoticeResponse getSpecificNotice(Long noticeId) {
+        NoticeResponse response = noticeService.getSpecificNotice(noticeId);
         return response;
     }
 }

--- a/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
+++ b/src/main/java/com/yanolja_final/domain/notice/service/NoticeService.java
@@ -6,7 +6,6 @@ import com.yanolja_final.domain.notice.dto.response.NoticeResponse;
 import com.yanolja_final.domain.notice.entity.Notice;
 import com.yanolja_final.domain.notice.exception.NoticeNotFoundException;
 import com.yanolja_final.domain.notice.repository.NoticeRepository;
-import com.yanolja_final.global.util.ResponseDTO;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,24 +16,23 @@ public class NoticeService {
 
     private final NoticeRepository noticeRepository;
 
-    public ResponseDTO<NoticeResponse> registerNotice(RegisterNoticeRequest request) {
+    public NoticeResponse registerNotice(RegisterNoticeRequest request) {
         Notice notice = request.toEntity();
         Notice newNotice = noticeRepository.save(notice);
-        return ResponseDTO.okWithData(NoticeResponse.fromNotice(newNotice));
+        NoticeResponse response = NoticeResponse.from(newNotice);
+        return response;
     }
 
-
-    public ResponseDTO<List<NoticeListResponse>> getNoticeList() {
+    public List<NoticeListResponse> getNoticeList() {
         List<Notice> notices = noticeRepository.findAll();
         List<NoticeListResponse> response = NoticeListResponse.fromNotices(notices);
-        return ResponseDTO.okWithData(response);
+        return response;
     }
 
-
-    public ResponseDTO<NoticeResponse> getSpecificNotice(Long noticeId) {
+    public NoticeResponse getSpecificNotice(Long noticeId) {
         Notice notice = noticeRepository.findById(noticeId)
             .orElseThrow(() -> new NoticeNotFoundException());
-        NoticeResponse response = NoticeResponse.fromNotice(notice);
-        return ResponseDTO.okWithData(response);
+        NoticeResponse response = NoticeResponse.from(notice);
+        return response;
     }
 }


### PR DESCRIPTION
## ⭐ 수정 후 점검을 위한 테스트 후 사진 첨부

### 공지사항 등록
![공지사항등록_테스트_수정후](https://github.com/yanolja-finalproject/Backend/assets/129931655/2ffe9e47-45d4-4d49-b752-50135e7db889)
![공지사항등록_테스트_수정후22](https://github.com/yanolja-finalproject/Backend/assets/129931655/c34bfa6a-d5fa-482f-be00-d779ec5bcc51)

### 공지사항 조회
![공지사항조회_테스트_수정후](https://github.com/yanolja-finalproject/Backend/assets/129931655/20fbed3d-ca59-4500-87a1-0260ec9e1297)

### 공지사항 세부조회
![공지사항 세부조회_테스트_수정후_1](https://github.com/yanolja-finalproject/Backend/assets/129931655/e376ddbb-ef54-4532-a409-a8eb4fb3c551)
![공지사항 세부조회_테스트_수정후_22](https://github.com/yanolja-finalproject/Backend/assets/129931655/5a7d3b87-589a-4de7-b40f-19c042c875c8)
![공지사항 세부조회_테스트_수정후_404NotFoundCustomizedException](https://github.com/yanolja-finalproject/Backend/assets/129931655/0174fb9e-4b84-4b30-bf02-30c8741ec755)

### 공지사항 테스트 관련 H2 사진
![공지사항등록_테스트_수정후_H2](https://github.com/yanolja-finalproject/Backend/assets/129931655/b7b62c06-8f97-44cf-a1d9-c8caccaaaebd)


### 📑 주요 작성/변경사항
* ResponseDTO 가 Controller 에서만 사용될 수 있도록 Service, Facade, Controller의 로직 변경
* Response Class의 fromNotice -> from() 메서드 명 변경 및 불필요한 줄바꿈 제거



