### PR TITLE
[feat] GET /v1/packages/compare 상품 비교하기

### DIFF
--- a/src/main/java/com/yanolja_final/domain/packages/controller/PackageController.java
+++ b/src/main/java/com/yanolja_final/domain/packages/controller/PackageController.java
@@ -1,6 +1,8 @@
 package com.yanolja_final.domain.packages.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yanolja_final.domain.packages.dto.response.PackageAvailableDateResponse;
+import com.yanolja_final.domain.packages.dto.response.PackageCompareResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageDetailResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageListItemResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageScheduleResponse;
@@ -56,5 +58,14 @@ public class PackageController {
     ) {
         List<PackageAvailableDateResponse> schedules = packageFacade.getAvailableDates(id);
         return ResponseDTO.okWithData(schedules);
+    }
+
+    @GetMapping("/compare")
+    public ResponseDTO<PackageCompareResponse> compare(
+        @RequestParam Long fixedPackageId,
+        @RequestParam Long comparePackageId
+    ) {
+        PackageCompareResponse compared = packageFacade.compare(fixedPackageId, comparePackageId);
+        return ResponseDTO.okWithData(compared);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/dto/response/PackageCompareResponse.java
+++ b/src/main/java/com/yanolja_final/domain/packages/dto/response/PackageCompareResponse.java
@@ -1,0 +1,8 @@
+package com.yanolja_final.domain.packages.dto.response;
+
+public record PackageCompareResponse(
+    PackageSummaryResponse fixedPackage,
+    PackageSummaryResponse comparePackage
+) {
+
+}

--- a/src/main/java/com/yanolja_final/domain/packages/dto/response/PackageSummaryResponse.java
+++ b/src/main/java/com/yanolja_final/domain/packages/dto/response/PackageSummaryResponse.java
@@ -1,0 +1,41 @@
+package com.yanolja_final.domain.packages.dto.response;
+
+import com.yanolja_final.domain.packages.entity.Package;
+import com.yanolja_final.domain.packages.entity.PackageDepartureOption;
+import com.yanolja_final.domain.review.entity.Review;
+import java.util.List;
+
+public record PackageSummaryResponse(
+    String title,
+    int price,
+    int hotelStars,
+    List<String> schedules,
+    int shoppingCount,
+    List<String> hashtags,
+    int lodgeDays,
+    int tripDays,
+    int reservationCount,
+    int minReservationCount,
+    int reviewCount,
+    double averageStars,
+    int purchasedCount
+) {
+
+    public static PackageSummaryResponse from(Package aPackage, PackageDepartureOption departureOption, int reviewCount, double averageStars, List<String> schedules) {
+        return new PackageSummaryResponse(
+            aPackage.getTitle(),
+            aPackage.getMinPrice(),
+            aPackage.getHotelStars(),
+            schedules,
+            aPackage.getShoppingCount(),
+            aPackage.getHashtagNames(),
+            aPackage.getLodgeDays(),
+            aPackage.getTripDays(),
+            departureOption.getCurrentReservationCount(),
+            departureOption.getMinReservationCount(),
+            reviewCount,
+            averageStars,
+            aPackage.getMonthlyPurchasedCount()
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
+++ b/src/main/java/com/yanolja_final/domain/packages/entity/Package.java
@@ -74,6 +74,9 @@ public class Package extends BaseEntity {
     private String exclusionList;
 
     @Column(nullable = false)
+    private Integer hotelStars;
+
+    @Column(nullable = false)
     private Integer viewedCount = 0;
 
     @Column(nullable = false)

--- a/src/main/java/com/yanolja_final/domain/packages/facade/PackageFacade.java
+++ b/src/main/java/com/yanolja_final/domain/packages/facade/PackageFacade.java
@@ -1,9 +1,13 @@
 package com.yanolja_final.domain.packages.facade;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yanolja_final.domain.packages.dto.response.PackageAvailableDateResponse;
+import com.yanolja_final.domain.packages.dto.response.PackageCompareResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageScheduleResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageDetailResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageListItemResponse;
+import com.yanolja_final.domain.packages.dto.response.PackageSummaryResponse;
 import com.yanolja_final.domain.packages.entity.Package;
 import com.yanolja_final.domain.packages.entity.PackageDepartureOption;
 import com.yanolja_final.domain.packages.service.PackageService;
@@ -15,6 +19,7 @@ import com.yanolja_final.domain.wish.service.WishService;
 import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
@@ -65,5 +70,32 @@ public class PackageFacade {
             .sorted(Comparator.comparing(PackageDepartureOption::getDepartureDate))
             .map(PackageAvailableDateResponse::from)
             .collect(Collectors.toList());
+    }
+
+    public PackageCompareResponse compare(Long fixedPackageId, Long comparePackageId) {
+        PackageSummaryResponse fixedPackage = getSummary(fixedPackageId);
+        PackageSummaryResponse comparePackage = getSummary(comparePackageId);
+
+        return new PackageCompareResponse(fixedPackage, comparePackage);
+    }
+
+    private PackageSummaryResponse getSummary(Long packageId) {
+        Package aPackage = packageService.findById(packageId);
+        PackageDepartureOption departureOption = aPackage.getAvailableDate(null);
+
+        List<PackageScheduleResponse> scheduleResponses = packageService.getSchedulesById(packageId);
+        List<String> schedules = scheduleResponses.stream()
+            .map(PackageScheduleResponse::schedule)
+            .flatMap(List::stream)
+            .collect(Collectors.toList());
+
+        List<Review> reviews = reviewService.findReviewsByPackageId(packageId);
+        int reviewCount = reviews.size();
+        int scoreSum = reviews.stream().mapToInt(Review::getTotalScore).sum();
+        double averageStars = reviewCount == 0 ? 0.0 : scoreSum / (double) reviewCount / 4;
+
+        return PackageSummaryResponse.from(
+            aPackage, departureOption, reviewCount, averageStars, schedules
+        );
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/service/PackageService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/PackageService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.yanolja_final.domain.packages.dto.response.PackageListItemResponse;
 import com.yanolja_final.domain.packages.dto.response.PackageScheduleResponse;
+import com.yanolja_final.domain.packages.dto.response.PackageSummaryResponse;
 import com.yanolja_final.domain.packages.entity.Package;
 import com.yanolja_final.domain.packages.exception.PackageNotFoundException;
 import com.yanolja_final.domain.packages.repository.PackageRepository;


### PR DESCRIPTION
closes #41 

## ⭐ 개요

### 종류
- [X] New Feature

### 📑 주요 작성/변경사항
- GET /v1/packages/compare 상품 비교하기 구현

### 💡 특이 사항 
- Package에 빠뜨렸던 hotelStars 필드 추가
  - 이에 따라 data.sql도 일괄 수정

### #️⃣ 스크린샷

<img width="858" alt="image" src="https://github.com/yanolja-finalproject/Backend/assets/33937365/f9bf6c5f-0421-49c7-bce4-7f439b8be741">

```json
{
    "code": 200,
    "data": {
        "fixedPackage": {
            "title": "[북해도 4일★출발확정]싱글족 모여라! 독실사용료 면제!+잔여석 1석",
            "price": 1499000,
            "hotelStars": 0,
            "schedules": [
                "인천공항 제 2 터미널 3층 H카운터 옆 미팅",
                "[LJ301]인천국제공항 제 2터미널 출발",
                "[LJ301]신치토세공항 도착",
                "노보리베츠로 이동 (약 50분 소요)",
                "일본 에도시대를 그대로 재현한 민속 테마파크 지다이무라 관광",
                "계곡에서 뿜어져 나오는 연기로 지옥을 연상케한다는 지옥계곡 관광",
                "조잔케이로 이동 (약 1시간 50분 소요)",
                "[미정] 석식 및 호텔 체크인 후 휴식(온천욕 포함)",
                "호텔조식 후",
                "오타루 이동 (약 1시간 소요)",
                "오타루의 대표적인 야경 명소 오타루 운하 관광",
                "오타루 대표 상품인 오르골을 약 3만개 보유한 오르골당 관광",
                "예쁜 유리 공예품을 구입할 수 있는 100년 전통 기타이치가라스관 관광",
                "일본 전국적으로도 유명한 오타루 과자거리 관광",
                "소운쿄 이동 (약 3시간 소요)",
                "일본의 100대 폭포의 하나로 부부폭포로 불리우는 은하폭포 유성폭포 관광",
                "[미정] 석식 및 호텔 체크인 후 휴식(온천욕 포함)",
                "호텔조식 후",
                "후라노 이동 (약 1시간 55분 소요)",
                "겨울의 낭만 팜 도미타 관광",
                "비에이 이동 (약 50분 소요)",
                "일본 CF에 자주 등장하는 비에이 명소 패치워크의 길 관광",
                "신비한 푸른 빛이 감도는 비에이 흰수염 폭포",
                "비에이 최고의 사진 명소인 청의 호수",
                "눈의 언덕 시키사이노오카 스노우 래프팅 체험",
                "삿포로 이동 (약 2시간 30분 소요)",
                "삿포로 오오도리 공원 관광",
                "[미정] 석식 후 호텔 이동",
                "호텔조식 후",
                "삿포로 시내 시계탑 차창관광",
                "면세점 1회 방문",
                "공항 이동 (약 1시간 소요)",
                "신치토세 공항 도착 후 출국 수속",
                "[LJ302]신치토세공항 출발",
                "인천국제공항 제 2 터미널 도착"
            ],
            "shoppingCount": 1,
            "hashtags": [],
            "lodgeDays": 3,
            "tripDays": 4,
            "reservationCount": 0,
            "minReservationCount": 15,
            "reviewCount": 0,
            "averageStars": 0.0,
            "purchasedCount": 0
        },
        "comparePackage": {
            "title": "[현대홈쇼핑][오사카4일] 대가족여행추천! 오사카 1일자유 포함 +USJ+나라+교토",
            "price": 799000,
            "hotelStars": 0,
            "schedules": [
                "인천공항 미팅",
                "ZE613 인천공항출발",
                "ZE613 간사이 국제공항 도착 ",
                "오사카 이동",
                "호텔 체크인 후 자유시간",
                "★추천 일정★",
                "3인실 배정 불가! 홀수 예약시 싱글차지 발생! (15만원)",
                "호텔 조식 후 ",
                "★전일정 자유일정★",
                "NO버스 NO가이드 중석식 불포함",
                "○추천일정○",
                "호텔 체크 인 후 휴식 ",
                "3인실 배정 불가! 홀수 예약시 싱글차지 발생! (15만원)",
                "호텔 조식 후",
                "#유니버셜 스튜디오 or 교토 선택 관광",
                "가이드와 교토팀 이동",
                "아라시야마 이동",
                "아라시야마의 상징 - 도게츠교/대나무숲 치쿠린",
                "교토 이동  ",
                "천년의 수도 교토 - 청수사",
                "교토의 핵심거리 - 산넨자카/니넨자카",
                "게이샤의 추억의 배경지 - 후시미이나리 신사",
                "오사카 이동",
                "오사카성(천수각불포함)",
                "예정호텔 : 라이즈 호텔 오사카 난바 (2인 1실 더블 트윈룸 랜덤배정 지정불가)",
                "자유시간 및 호텔이동후 휴식",
                "3인실 배정 불가! 홀수 예약시 싱글차지 발생! (15만원)",
                "호텔 조식 후",
                "일본관광공사 면세점 방문",
                "신사이바시/도톤보리 관광",
                "나라 이동",
                "오래된 목조 건축양식인 동대사 관광",
                "사슴들을 가까이서 직접 볼 수 있는 나라 사슴공원",
                "간사이 공항으로 이동",
                "ZE614 간사이 공항출발 ",
                "ZE614 인천 국제공항 도착",
                "인터파크를 이용해주셔서 감사합니다 "
            ],
            "shoppingCount": 1,
            "hashtags": [],
            "lodgeDays": 3,
            "tripDays": 4,
            "reservationCount": 3,
            "minReservationCount": 15,
            "reviewCount": 0,
            "averageStars": 0.0,
            "purchasedCount": 0
        }
    }
}
```