### PR TITLE
[Feature] v1/search/options/destinations (검색옵션) 나라,대륙 목록 조회 기능 구현

### DIFF
--- a/src/main/java/com/yanolja_final/domain/packages/dto/response/ContinentResponse.java
+++ b/src/main/java/com/yanolja_final/domain/packages/dto/response/ContinentResponse.java
@@ -1,0 +1,16 @@
+package com.yanolja_final.domain.packages.dto.response;
+
+import com.yanolja_final.domain.packages.entity.Continent;
+
+public record ContinentResponse(
+    String name,
+    String imageUrl
+) {
+
+    public static ContinentResponse from(Continent continent) {
+        return new ContinentResponse(
+            continent.getName(),
+            continent.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/packages/dto/response/NationResponse.java
+++ b/src/main/java/com/yanolja_final/domain/packages/dto/response/NationResponse.java
@@ -1,0 +1,16 @@
+package com.yanolja_final.domain.packages.dto.response;
+
+import com.yanolja_final.domain.packages.entity.Nation;
+
+public record NationResponse(
+    String name,
+    String imageUrl
+) {
+
+    public static NationResponse from(Nation nation) {
+        return new NationResponse(
+            nation.getName(),
+            nation.getImageUrl()
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/packages/repository/ContinentRepository.java
+++ b/src/main/java/com/yanolja_final/domain/packages/repository/ContinentRepository.java
@@ -1,0 +1,10 @@
+package com.yanolja_final.domain.packages.repository;
+
+import com.yanolja_final.domain.packages.entity.Continent;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ContinentRepository extends JpaRepository<Continent, Long> {
+
+    List<Continent> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/yanolja_final/domain/packages/repository/NationRepository.java
+++ b/src/main/java/com/yanolja_final/domain/packages/repository/NationRepository.java
@@ -1,0 +1,10 @@
+package com.yanolja_final.domain.packages.repository;
+
+import com.yanolja_final.domain.packages.entity.Nation;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface NationRepository extends JpaRepository<Nation, Long> {
+
+    List<Nation> findAllByOrderByNameAsc();
+}

--- a/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
@@ -1,5 +1,6 @@
 package com.yanolja_final.domain.search.controller;
 
+import com.yanolja_final.domain.search.controller.response.ContinentNationResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
 import com.yanolja_final.domain.search.facade.SearchFacade;
 import com.yanolja_final.global.util.ResponseDTO;
@@ -18,9 +19,16 @@ public class SearchController {
     private final SearchFacade searchFacade;
 
     @GetMapping("/options/hashtags")
-    public ResponseEntity<ResponseDTO<List<HashtagResponse>>> getAllHashtag(){
+    public ResponseEntity<ResponseDTO<List<HashtagResponse>>> getAllHashtag() {
         return ResponseEntity.ok(
             ResponseDTO.okWithData(searchFacade.getHashtags())
+        );
+    }
+
+    @GetMapping("/options/destinations")
+    public ResponseEntity<ResponseDTO<List<ContinentNationResponse>>> getAllContinentAndNationInfo() {
+        return ResponseEntity.ok(
+            ResponseDTO.okWithData(searchFacade.getAllContinentAndNationInfo())
         );
     }
 }

--- a/src/main/java/com/yanolja_final/domain/search/controller/response/ContinentNationResponse.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/response/ContinentNationResponse.java
@@ -1,0 +1,25 @@
+package com.yanolja_final.domain.search.controller.response;
+
+import com.yanolja_final.domain.packages.dto.response.ContinentResponse;
+import com.yanolja_final.domain.packages.dto.response.NationResponse;
+import com.yanolja_final.domain.packages.entity.Continent;
+import com.yanolja_final.domain.packages.entity.Nation;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record ContinentNationResponse(
+    List<NationResponse> nations,
+    List<ContinentResponse> continents
+) {
+
+    public static ContinentNationResponse from(List<Nation> nations, List<Continent> continents) {
+        return new ContinentNationResponse(
+            nations.stream()
+                .map(NationResponse::from)
+                .collect(Collectors.toList()),
+            continents.stream()
+                .map(ContinentResponse::from)
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
+++ b/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
@@ -1,7 +1,11 @@
 package com.yanolja_final.domain.search.facade;
 
-import com.yanolja_final.domain.packages.entity.Hashtag;
+import com.yanolja_final.domain.packages.entity.Continent;
+import com.yanolja_final.domain.packages.entity.Nation;
+import com.yanolja_final.domain.packages.repository.ContinentRepository;
 import com.yanolja_final.domain.packages.repository.HashtagRepository;
+import com.yanolja_final.domain.packages.repository.NationRepository;
+import com.yanolja_final.domain.search.controller.response.ContinentNationResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,10 +19,18 @@ import org.springframework.transaction.annotation.Transactional;
 public class SearchFacade {
 
     private final HashtagRepository hashtagRepository;
+    private final NationRepository nationRepository;
+    private final ContinentRepository continentRepository;
 
     public List<HashtagResponse> getHashtags() {
         return hashtagRepository.findAllByOrderByNameAsc().stream()
             .map(HashtagResponse::from)
             .collect(Collectors.toList());
+    }
+
+    public List<ContinentNationResponse> getAllContinentAndNationInfo() {
+        List<Nation> nations = nationRepository.findAllByOrderByNameAsc();
+        List<Continent> continents = continentRepository.findAllByOrderByNameAsc();
+        return List.of(ContinentNationResponse.from(nations, continents));
     }
 }


### PR DESCRIPTION
## ⭐ 개요
- (검색 옵션) 나라,대륙 목록 조회 기능 구현

### 종류
- [ ] New Feature

### 💡 특이 사항 
- 이전 pr도 마찬가지지만, `SearchFacade` 내에 `service`가 아닌 `repository`사용.
(로직이 기본적인 로직만 사용되기에 service를 따로 두지 않음)

### #️⃣ Issue Link - #55 

