### PR TITLE
[Feature] v1/search/hashtags 해시태그 목록 (검색 내림차순 순) 기능 구현 & (검색옵션) 나라,대륙 기능 수정

### DIFF
--- a/src/main/java/com/yanolja_final/domain/packages/repository/HashtagRepository.java
+++ b/src/main/java/com/yanolja_final/domain/packages/repository/HashtagRepository.java
@@ -8,4 +8,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface HashtagRepository extends JpaRepository<Hashtag, Long> {
 
     List<Hashtag> findAllByOrderByNameAsc();
+    List<Hashtag> findByOrderBySearchedCountDesc();
 }

--- a/src/main/java/com/yanolja_final/domain/packages/repository/NationRepository.java
+++ b/src/main/java/com/yanolja_final/domain/packages/repository/NationRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface NationRepository extends JpaRepository<Nation, Long> {
 
-    List<Nation> findAllByOrderByNameAsc();
+    List<Nation> findByIdIn(List<Long> ids);
 }

--- a/src/main/java/com/yanolja_final/domain/packages/service/ContinentService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/ContinentService.java
@@ -1,0 +1,20 @@
+package com.yanolja_final.domain.packages.service;
+
+import com.yanolja_final.domain.packages.entity.Continent;
+import com.yanolja_final.domain.packages.repository.ContinentRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ContinentService {
+
+    public final ContinentRepository continentRepository;
+
+    public List<Continent> getAllContinentInfo() {
+        return continentRepository.findAllByOrderByNameAsc();
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/packages/service/HashtagService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/HashtagService.java
@@ -1,5 +1,6 @@
 package com.yanolja_final.domain.packages.service;
 
+import com.yanolja_final.domain.packages.entity.Hashtag;
 import com.yanolja_final.domain.packages.repository.HashtagRepository;
 import com.yanolja_final.domain.search.controller.response.HashTagNamesResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
@@ -22,7 +23,7 @@ public class HashtagService {
             .collect(Collectors.toList());
     }
 
-    public HashTagNamesResponse findAllByOrderBySearchCountDesc() {
-        return HashTagNamesResponse.from(hashtagRepository.findByOrderBySearchedCountDesc());
+    public List<Hashtag> findAllByOrderBySearchedCountDesc() {
+        return hashtagRepository.findByOrderBySearchedCountDesc();
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/service/HashtagService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/HashtagService.java
@@ -1,6 +1,7 @@
 package com.yanolja_final.domain.packages.service;
 
 import com.yanolja_final.domain.packages.repository.HashtagRepository;
+import com.yanolja_final.domain.search.controller.response.HashTagNamesResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -19,5 +20,9 @@ public class HashtagService {
         return hashtagRepository.findAllByOrderByNameAsc().stream()
             .map(HashtagResponse::from)
             .collect(Collectors.toList());
+    }
+
+    public HashTagNamesResponse findAllByOrderBySearchCountDesc() {
+        return HashTagNamesResponse.from(hashtagRepository.findByOrderBySearchedCountDesc());
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/service/HashtagService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/HashtagService.java
@@ -1,0 +1,23 @@
+package com.yanolja_final.domain.packages.service;
+
+import com.yanolja_final.domain.packages.repository.HashtagRepository;
+import com.yanolja_final.domain.search.controller.response.HashtagResponse;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HashtagService {
+
+    private final HashtagRepository hashtagRepository;
+
+    public List<HashtagResponse> getAllHashtagInfo() {
+        return hashtagRepository.findAllByOrderByNameAsc().stream()
+            .map(HashtagResponse::from)
+            .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/packages/service/NationService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/NationService.java
@@ -2,6 +2,7 @@ package com.yanolja_final.domain.packages.service;
 
 import com.yanolja_final.domain.packages.entity.Nation;
 import com.yanolja_final.domain.packages.repository.NationRepository;
+import java.util.Arrays;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -14,7 +15,10 @@ public class NationService {
 
     public final NationRepository nationRepository;
 
-    public List<Nation> getAllNationInfo() {
-        return nationRepository.findAllByOrderByNameAsc();
+    // 일본, 중국, 태국, 베트남, 미국, 대만 순서대로 국가 ID를 리스트에 담습니다.
+    private static final List<Long> nationIds = Arrays.asList(5L, 19L, 8L, 1L, 13L, 17L);
+
+    public List<Nation> getPopularNationInfo() {
+        return nationRepository.findByIdIn(nationIds);
     }
 }

--- a/src/main/java/com/yanolja_final/domain/packages/service/NationService.java
+++ b/src/main/java/com/yanolja_final/domain/packages/service/NationService.java
@@ -1,0 +1,20 @@
+package com.yanolja_final.domain.packages.service;
+
+import com.yanolja_final.domain.packages.entity.Nation;
+import com.yanolja_final.domain.packages.repository.NationRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class NationService {
+
+    public final NationRepository nationRepository;
+
+    public List<Nation> getAllNationInfo() {
+        return nationRepository.findAllByOrderByNameAsc();
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
@@ -1,6 +1,7 @@
 package com.yanolja_final.domain.search.controller;
 
 import com.yanolja_final.domain.search.controller.response.ContinentNationResponse;
+import com.yanolja_final.domain.search.controller.response.HashTagNamesResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
 import com.yanolja_final.domain.search.facade.SearchFacade;
 import com.yanolja_final.global.util.ResponseDTO;
@@ -29,6 +30,13 @@ public class SearchController {
     public ResponseEntity<ResponseDTO<List<ContinentNationResponse>>> getAllContinentAndNationInfo() {
         return ResponseEntity.ok(
             ResponseDTO.okWithData(searchFacade.getAllContinentAndNationInfo())
+        );
+    }
+
+    @GetMapping("/hashtags")
+    public ResponseEntity<ResponseDTO<HashTagNamesResponse>> getAllHashtagNameBySearchedCountDesc() {
+        return ResponseEntity.ok(
+            ResponseDTO.okWithData(searchFacade.findAllByOrderBySearchCountDesc())
         );
     }
 }

--- a/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
@@ -36,7 +36,7 @@ public class SearchController {
     @GetMapping("/hashtags")
     public ResponseEntity<ResponseDTO<HashTagNamesResponse>> getAllHashtagNameBySearchedCountDesc() {
         return ResponseEntity.ok(
-            ResponseDTO.okWithData(searchFacade.findAllByOrderBySearchCountDesc())
+            ResponseDTO.okWithData(searchFacade.findAllByOrderBySearchedCountDesc())
         );
     }
 }

--- a/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/SearchController.java
@@ -29,7 +29,7 @@ public class SearchController {
     @GetMapping("/options/destinations")
     public ResponseEntity<ResponseDTO<List<ContinentNationResponse>>> getAllContinentAndNationInfo() {
         return ResponseEntity.ok(
-            ResponseDTO.okWithData(searchFacade.getAllContinentAndNationInfo())
+            ResponseDTO.okWithData(searchFacade.getAllContinentAndPopularNationInfo())
         );
     }
 

--- a/src/main/java/com/yanolja_final/domain/search/controller/response/ContinentNationResponse.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/response/ContinentNationResponse.java
@@ -1,7 +1,5 @@
 package com.yanolja_final.domain.search.controller.response;
 
-import com.yanolja_final.domain.packages.dto.response.ContinentResponse;
-import com.yanolja_final.domain.packages.dto.response.NationResponse;
 import com.yanolja_final.domain.packages.entity.Continent;
 import com.yanolja_final.domain.packages.entity.Nation;
 import java.util.List;

--- a/src/main/java/com/yanolja_final/domain/search/controller/response/ContinentResponse.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/response/ContinentResponse.java
@@ -1,4 +1,4 @@
-package com.yanolja_final.domain.packages.dto.response;
+package com.yanolja_final.domain.search.controller.response;
 
 import com.yanolja_final.domain.packages.entity.Continent;
 

--- a/src/main/java/com/yanolja_final/domain/search/controller/response/HashTagNamesResponse.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/response/HashTagNamesResponse.java
@@ -1,0 +1,20 @@
+package com.yanolja_final.domain.search.controller.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.yanolja_final.domain.packages.entity.Hashtag;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public record HashTagNamesResponse(
+    @JsonProperty("hashtags")
+    List<String> names
+) {
+
+    public static HashTagNamesResponse from(List<Hashtag> hashtags){
+        return new HashTagNamesResponse(
+            hashtags.stream()
+                .map(Hashtag::getName)
+                .collect(Collectors.toList())
+        );
+    }
+}

--- a/src/main/java/com/yanolja_final/domain/search/controller/response/NationResponse.java
+++ b/src/main/java/com/yanolja_final/domain/search/controller/response/NationResponse.java
@@ -1,4 +1,4 @@
-package com.yanolja_final.domain.packages.dto.response;
+package com.yanolja_final.domain.search.controller.response;
 
 import com.yanolja_final.domain.packages.entity.Nation;
 

--- a/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
+++ b/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
@@ -6,6 +6,7 @@ import com.yanolja_final.domain.packages.repository.ContinentRepository;
 import com.yanolja_final.domain.packages.repository.HashtagRepository;
 import com.yanolja_final.domain.packages.repository.NationRepository;
 import com.yanolja_final.domain.packages.service.ContinentService;
+import com.yanolja_final.domain.packages.service.HashtagService;
 import com.yanolja_final.domain.packages.service.NationService;
 import com.yanolja_final.domain.search.controller.response.ContinentNationResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
@@ -20,14 +21,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional(readOnly = true)
 public class SearchFacade {
 
-    private final HashtagRepository hashtagRepository;
+    private final HashtagService hashtagService;
     private final NationService nationService;
     private final ContinentService continentService;
 
     public List<HashtagResponse> getHashtags() {
-        return hashtagRepository.findAllByOrderByNameAsc().stream()
-            .map(HashtagResponse::from)
-            .collect(Collectors.toList());
+        return hashtagService.getAllHashtagInfo();
     }
 
     public List<ContinentNationResponse> getAllContinentAndNationInfo() {

--- a/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
+++ b/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
@@ -26,8 +26,8 @@ public class SearchFacade {
         return hashtagService.getAllHashtagInfo();
     }
 
-    public List<ContinentNationResponse> getAllContinentAndNationInfo() {
-        List<Nation> nations = nationService.getAllNationInfo();
+    public List<ContinentNationResponse> getAllContinentAndPopularNationInfo() {
+        List<Nation> nations = nationService.getPopularNationInfo();
         List<Continent> continents = continentService.getAllContinentInfo();
         return List.of(ContinentNationResponse.from(nations, continents));
     }

--- a/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
+++ b/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
@@ -32,7 +32,7 @@ public class SearchFacade {
         return List.of(ContinentNationResponse.from(nations, continents));
     }
 
-    public HashTagNamesResponse findAllByOrderBySearchCountDesc() {
-        return hashtagService.findAllByOrderBySearchCountDesc();
+    public HashTagNamesResponse findAllByOrderBySearchedCountDesc() {
+        return HashTagNamesResponse.from(hashtagService.findAllByOrderBySearchedCountDesc());
     }
 }

--- a/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
+++ b/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
@@ -5,6 +5,8 @@ import com.yanolja_final.domain.packages.entity.Nation;
 import com.yanolja_final.domain.packages.repository.ContinentRepository;
 import com.yanolja_final.domain.packages.repository.HashtagRepository;
 import com.yanolja_final.domain.packages.repository.NationRepository;
+import com.yanolja_final.domain.packages.service.ContinentService;
+import com.yanolja_final.domain.packages.service.NationService;
 import com.yanolja_final.domain.search.controller.response.ContinentNationResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
 import java.util.List;
@@ -19,8 +21,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class SearchFacade {
 
     private final HashtagRepository hashtagRepository;
-    private final NationRepository nationRepository;
-    private final ContinentRepository continentRepository;
+    private final NationService nationService;
+    private final ContinentService continentService;
 
     public List<HashtagResponse> getHashtags() {
         return hashtagRepository.findAllByOrderByNameAsc().stream()
@@ -29,8 +31,8 @@ public class SearchFacade {
     }
 
     public List<ContinentNationResponse> getAllContinentAndNationInfo() {
-        List<Nation> nations = nationRepository.findAllByOrderByNameAsc();
-        List<Continent> continents = continentRepository.findAllByOrderByNameAsc();
+        List<Nation> nations = nationService.getAllNationInfo();
+        List<Continent> continents = continentService.getAllContinentInfo();
         return List.of(ContinentNationResponse.from(nations, continents));
     }
 }

--- a/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
+++ b/src/main/java/com/yanolja_final/domain/search/facade/SearchFacade.java
@@ -2,16 +2,13 @@ package com.yanolja_final.domain.search.facade;
 
 import com.yanolja_final.domain.packages.entity.Continent;
 import com.yanolja_final.domain.packages.entity.Nation;
-import com.yanolja_final.domain.packages.repository.ContinentRepository;
-import com.yanolja_final.domain.packages.repository.HashtagRepository;
-import com.yanolja_final.domain.packages.repository.NationRepository;
 import com.yanolja_final.domain.packages.service.ContinentService;
 import com.yanolja_final.domain.packages.service.HashtagService;
 import com.yanolja_final.domain.packages.service.NationService;
 import com.yanolja_final.domain.search.controller.response.ContinentNationResponse;
+import com.yanolja_final.domain.search.controller.response.HashTagNamesResponse;
 import com.yanolja_final.domain.search.controller.response.HashtagResponse;
 import java.util.List;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -33,5 +30,9 @@ public class SearchFacade {
         List<Nation> nations = nationService.getAllNationInfo();
         List<Continent> continents = continentService.getAllContinentInfo();
         return List.of(ContinentNationResponse.from(nations, continents));
+    }
+
+    public HashTagNamesResponse findAllByOrderBySearchCountDesc() {
+        return hashtagService.findAllByOrderBySearchCountDesc();
     }
 }


### PR DESCRIPTION
## ⭐ 개요
- 해시태그 이름 전체 조회 (searchedCount 순)

### 종류
- [x] New Feature
- [x] Refactor

### 📑 주요 작성/변경사항
- [] 파일 위치 변경 및 nation/hashtag/continent service 추가
- [] (검색옵션)나라,대륙 part 나라 기존 전체 데이터 -> 인기있는 6개 나라(고정) 만 보내주도록 수정

### 💡 특이 사항 

### #️⃣ Issue Link - #68 

### Reference
![image](https://github.com/yanolja-finalproject/Backend/assets/87019291/91a3d4fa-a1a7-4fee-b98a-3af1b683e0f6)

![image](https://github.com/yanolja-finalproject/Backend/assets/87019291/9e1c446f-6472-4582-ab1b-a6ffb4236f94)
