### PR TITLE
[Refactor] OAuth2 동일 이메일 가입 요청시 예외처리 추가

### DIFF
--- a/src/main/java/com/yanolja_final/global/config/security/PrincipalOauth2UserService.java
+++ b/src/main/java/com/yanolja_final/global/config/security/PrincipalOauth2UserService.java
@@ -49,27 +49,26 @@ public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
             oauth2Userinfo = new NaverUserInfo((Map) oauth2User.getAttributes().get("response"));
         }
 
-        Optional<User> user = userRepository.findByEmailAndProvider(
-            oauth2Userinfo.getEmail(), oauth2Userinfo.getProvider());
+        Optional<User> userOptional = userRepository.findByEmail(oauth2Userinfo.getEmail());
 
-        //이미 소셜로그인을 한적이 있는지 없는지
-        if (user.isEmpty()) {
-
-            User newUser = User.builder()
+        User user;
+        if (userOptional.isPresent()) {
+            user = userOptional.get();
+        } else {
+            user = User.builder()
                 .email(oauth2Userinfo.getEmail())
                 .username(oauth2Userinfo.getName())
-                .encryptedPassword("OAuth2")  //Oauth2로 로그인을 해서 패스워드는 의미없음.
+                .encryptedPassword("OAuth2") // OAuth2 로그인 사용시 패스워드는 의미가 없습니다.
                 .phoneNumber(oauth2Userinfo.getPhoneNumber())
                 .authorities(DEFAULT_AUTHORITIES)
                 .provider(provider)
                 .build();
 
-            userRepository.save(newUser);
-
-            return new PrincipalDetails(newUser, oauth2User.getAttributes());
-        } else {
-
-            return new PrincipalDetails(user.get(), oauth2User.getAttributes());
+            userRepository.save(user);
         }
+
+        return new PrincipalDetails(user, oauth2User.getAttributes());
     }
 }
+
+

--- a/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
+++ b/src/main/java/com/yanolja_final/global/exception/ErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum ErrorCode {
 
     // EMAIL
-    EMAIL_SENDING_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패했습니다."),
+    EMAIL_SENDING_FAILURE(HttpStatus.BAD_REQUEST, "이메일 전송에 실패했습니다."),
     EMAIL_TEMPLATE_LOAD_FAILURE(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 템플릿 로드에 실패했습니다."),
     EMAIL_VERIFY_FAILURE(HttpStatus.BAD_REQUEST, "인증번호가 일치하지 않습니다."),
 


### PR DESCRIPTION
## ⭐ [Refactor] OAuth2 동일 이메일 가입 요청시 예외처리 추가

- 동일 이메일로 서로 다른 소셜 로그인 요청시 이미 가입되어 있는 계정으로 로그인을 진행하도록 로직을 수정했습니다.

### 💡 특이 사항 
- 로컬에서는 테스트가 성공하지만 배포 후 다시 테스트 해 봐야함

### #️⃣ Issue Link - #70 
